### PR TITLE
CASSANDRA-20404 more refactorisation

### DIFF
--- a/src/java/org/apache/cassandra/auth/MutualTlsAuthenticator.java
+++ b/src/java/org/apache/cassandra/auth/MutualTlsAuthenticator.java
@@ -44,7 +44,7 @@ import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.utils.NoSpamLogger;
 
 import static org.apache.cassandra.auth.IAuthenticator.AuthenticationMode.MTLS;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 
 /**
  * Performs mTLS authentication for client connections by extracting identities from client certificate

--- a/src/java/org/apache/cassandra/auth/MutualTlsInternodeAuthenticator.java
+++ b/src/java/org/apache/cassandra/auth/MutualTlsInternodeAuthenticator.java
@@ -49,7 +49,7 @@ import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.metrics.MutualTlsMetrics;
 import org.apache.cassandra.utils.NoSpamLogger;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 
 /**
  * Performs mTLS authentication for internode connections by extracting identities from the certificates of incoming

--- a/src/java/org/apache/cassandra/auth/MutualTlsWithPasswordFallbackAuthenticator.java
+++ b/src/java/org/apache/cassandra/auth/MutualTlsWithPasswordFallbackAuthenticator.java
@@ -81,7 +81,7 @@ public class MutualTlsWithPasswordFallbackAuthenticator extends PasswordAuthenti
     public void validateConfiguration() throws ConfigurationException
     {
         Config config = DatabaseDescriptor.getRawConfig();
-        if (config.client_encryption_options.getClientAuth() == EncryptionOptions.ClientAuth.NOT_REQUIRED)
+        if (config.client_encryption_options.getClientAuth() == EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED)
         {
             String msg = "MutualTlsWithPasswordFallbackAuthenticator requires client_encryption_options.require_client_auth to be optional/true";
             throw new ConfigurationException(msg);

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -439,7 +439,7 @@ public class Config
     public String failure_detector = "FailureDetector";
 
     public EncryptionOptions.ServerEncryptionOptions server_encryption_options = new EncryptionOptions.ServerEncryptionOptions();
-    public EncryptionOptions client_encryption_options = new EncryptionOptions();
+    public EncryptionOptions.ClientEncryptionOptions client_encryption_options = new EncryptionOptions.ClientEncryptionOptions();
 
     public JMXServerOptions jmx_server_options;
 

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -154,7 +154,7 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.UNSAFE_SYS
 import static org.apache.cassandra.config.DataRateSpec.DataRateUnit.BYTES_PER_SECOND;
 import static org.apache.cassandra.config.DataRateSpec.DataRateUnit.MEBIBYTES_PER_SECOND;
 import static org.apache.cassandra.config.DataStorageSpec.DataStorageUnit.MEBIBYTES;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.apache.cassandra.db.ConsistencyLevel.ALL;
 import static org.apache.cassandra.db.ConsistencyLevel.EACH_QUORUM;
 import static org.apache.cassandra.db.ConsistencyLevel.LOCAL_QUORUM;
@@ -996,15 +996,16 @@ public class DatabaseDescriptor
         {
             conf.jmx_server_options = JMXServerOptions.createParsingSystemProperties();
         }
-        else if (JMXServerOptions.isEnabledBySystemProperties())
+        else
         {
-            throw new ConfigurationException("Configure either jmx_server_options in cassandra.yaml and comment out " +
-                                             "configure_jmx function call in cassandra-env.sh or keep cassandra-env.sh " +
-                                             "to call configure_jmx function but you have to keep jmx_server_options " +
-                                             "in cassandra.yaml commented out.");
+            if (JMXServerOptions.isEnabledBySystemProperties())
+                throw new ConfigurationException("Configure either jmx_server_options in cassandra.yaml and comment out " +
+                                                 "configure_jmx function call in cassandra-env.sh or keep cassandra-env.sh " +
+                                                 "to call configure_jmx function but you have to keep jmx_server_options " +
+                                                 "in cassandra.yaml commented out.");
+            else
+                conf.jmx_server_options.jmx_encryption_options.applyConfig();
         }
-
-        conf.jmx_server_options.jmx_encryption_options.applyConfig();
 
         if (conf.snapshot_links_per_second < 0)
             throw new ConfigurationException("snapshot_links_per_second must be >= 0");
@@ -3812,7 +3813,7 @@ public class DatabaseDescriptor
         conf.server_encryption_options = encryptionOptions;
     }
 
-    public static EncryptionOptions getNativeProtocolEncryptionOptions()
+    public static EncryptionOptions.ClientEncryptionOptions getNativeProtocolEncryptionOptions()
     {
         return conf.client_encryption_options;
     }
@@ -3823,7 +3824,7 @@ public class DatabaseDescriptor
     }
 
     @VisibleForTesting
-    public static void updateNativeProtocolEncryptionOptions(Function<EncryptionOptions, EncryptionOptions> update)
+    public static void updateNativeProtocolEncryptionOptions(Function<EncryptionOptions.ClientEncryptionOptions, EncryptionOptions.ClientEncryptionOptions> update)
     {
         conf.client_encryption_options = update.apply(conf.client_encryption_options);
     }

--- a/src/java/org/apache/cassandra/config/EncryptionOptions.java
+++ b/src/java/org/apache/cassandra/config/EncryptionOptions.java
@@ -45,10 +45,8 @@ import static org.apache.cassandra.utils.LocalizeString.toLowerCaseLocalized;
  * Examples of such options are: supported cipher-suites, ssl protocol with version, accepted protocols, end-point
  * verification, require client-auth/cert etc.
  */
-public class EncryptionOptions
+public abstract class EncryptionOptions<T extends EncryptionOptions<T>>
 {
-    Logger logger = LoggerFactory.getLogger(EncryptionOptions.class);
-
     public enum TlsEncryptionPolicy
     {
         UNENCRYPTED("unencrypted"),
@@ -68,39 +66,50 @@ public class EncryptionOptions
         }
     }
 
-    public enum ClientAuth
+    public enum ConfigKey
     {
-        REQUIRED("true"),
-        NOT_REQUIRED("false"),
-        OPTIONAL("optional");
-        private final String value;
-        private static final Map<String, ClientAuth> VALUES = new HashMap<>();
-        static
+        KEYSTORE("keystore"),
+        KEYSTORE_PASSWORD("keystore_password"),
+        KEYSTORE_PASSWORD_FILE("keystore_password_file"),
+        OUTBOUND_KEYSTORE("outbound_keystore"),
+        OUTBOUND_KEYSTORE_PASSWORD("outbound_keystore_password"),
+        OUTBOUND_KEYSTORE_PASSWORD_FILE("outbound_keystore_password_file"),
+        TRUSTSTORE("truststore"),
+        TRUSTSTORE_PASSWORD("truststore_password"),
+        TRUSTSTORE_PASSWORD_FILE("truststore_password_file"),
+        CIPHER_SUITES("cipher_suites"),
+        PROTOCOL("protocol"),
+        ACCEPTED_PROTOCOLS("accepted_protocols"),
+        ALGORITHM("algorithm"),
+        STORE_TYPE("store_type"),
+        REQUIRE_CLIENT_AUTH("require_client_auth"),
+        REQUIRE_ENDPOINT_VERIFICATION("require_endpoint_verification"),
+        ENABLED("enabled"),
+        OPTIONAL("optional"),
+        MAX_CERTIFICATE_VALIDITY_PERIOD("max_certificate_validity_period"),
+        CERTIFICATE_VALIDITY_WARN_THRESHOLD("certificate_validity_warn_threshold");
+
+        final String keyName;
+
+        ConfigKey(String keyName)
         {
-            for (ClientAuth clientAuth : ClientAuth.values())
+            this.keyName = keyName;
+        }
+
+        public String toString()
+        {
+            return keyName;
+        }
+
+        static Set<String> asSet()
+        {
+            Set<String> valueSet = new HashSet<>();
+            ConfigKey[] values = values();
+            for (ConfigKey key : values)
             {
-                VALUES.put(clientAuth.value, clientAuth);
-                VALUES.put(toLowerCaseLocalized(clientAuth.name()), clientAuth);
+                valueSet.add(toLowerCaseLocalized(key.toString()));
             }
-        }
-
-        ClientAuth(String value)
-        {
-            this.value = value;
-        }
-
-        public static ClientAuth from(String value)
-        {
-            if (VALUES.containsKey(toLowerCaseLocalized(value)))
-            {
-                return VALUES.get(toLowerCaseLocalized(value));
-            }
-            throw new ConfigurationException(value + " is not a valid ClientAuth option");
-        }
-
-        public String value()
-        {
-            return value;
+            return valueSet;
         }
     }
 
@@ -151,53 +160,6 @@ public class EncryptionOptions
      * to use this option instance.
      */
     public transient ISslContextFactory sslContextFactoryInstance;
-
-    public enum ConfigKey
-    {
-        KEYSTORE("keystore"),
-        KEYSTORE_PASSWORD("keystore_password"),
-        KEYSTORE_PASSWORD_FILE("keystore_password_file"),
-        OUTBOUND_KEYSTORE("outbound_keystore"),
-        OUTBOUND_KEYSTORE_PASSWORD("outbound_keystore_password"),
-        OUTBOUND_KEYSTORE_PASSWORD_FILE("outbound_keystore_password_file"),
-        TRUSTSTORE("truststore"),
-        TRUSTSTORE_PASSWORD("truststore_password"),
-        TRUSTSTORE_PASSWORD_FILE("truststore_password_file"),
-        CIPHER_SUITES("cipher_suites"),
-        PROTOCOL("protocol"),
-        ACCEPTED_PROTOCOLS("accepted_protocols"),
-        ALGORITHM("algorithm"),
-        STORE_TYPE("store_type"),
-        REQUIRE_CLIENT_AUTH("require_client_auth"),
-        REQUIRE_ENDPOINT_VERIFICATION("require_endpoint_verification"),
-        ENABLED("enabled"),
-        OPTIONAL("optional"),
-        MAX_CERTIFICATE_VALIDITY_PERIOD("max_certificate_validity_period"),
-        CERTIFICATE_VALIDITY_WARN_THRESHOLD("certificate_validity_warn_threshold");
-
-        final String keyName;
-
-        ConfigKey(String keyName)
-        {
-            this.keyName = keyName;
-        }
-
-        public String toString()
-        {
-            return keyName;
-        }
-
-        static Set<String> asSet()
-        {
-            Set<String> valueSet = new HashSet<>();
-            ConfigKey[] values = values();
-            for (ConfigKey key : values)
-            {
-                valueSet.add(toLowerCaseLocalized(key.toString()));
-            }
-            return valueSet;
-        }
-    }
 
     public EncryptionOptions()
     {
@@ -251,7 +213,7 @@ public class EncryptionOptions
         this.certificate_validity_warn_threshold = certificate_validity_warn_threshold;
     }
 
-    public EncryptionOptions(EncryptionOptions options)
+    public EncryptionOptions(EncryptionOptions<T> options)
     {
         ssl_context_factory = options.ssl_context_factory;
         keystore = options.keystore;
@@ -279,7 +241,7 @@ public class EncryptionOptions
      *
      * It also initializes the ISslContextFactory's instance
      */
-    public EncryptionOptions applyConfig()
+    public T applyConfig()
     {
         ensureConfigNotApplied();
 
@@ -303,7 +265,7 @@ public class EncryptionOptions
             // Otherwise if there's no keystore, not possible to establish an optional secure connection
             isOptional = false;
         }
-        return this;
+        return (T) this;
     }
 
     /**
@@ -311,22 +273,22 @@ public class EncryptionOptions
      * as the constructor for its implementation.
      *
      * @throws IllegalArgumentException in case any pre-defined key, as per {@link ConfigKey}, for the encryption
-     * options is duplicated in the parameterized keys.
+     *                                  options is duplicated in the parameterized keys.
      */
-    private void prepareSslContextFactoryParameterizedKeys(Map<String,Object> sslContextFactoryParameters)
+    private void prepareSslContextFactoryParameterizedKeys(Map<String, Object> sslContextFactoryParameters)
     {
         if (ssl_context_factory.parameters != null)
         {
             Set<String> configKeys = ConfigKey.asSet();
             for (Map.Entry<String, String> entry : ssl_context_factory.parameters.entrySet())
             {
-                if(configKeys.contains(toLowerCaseLocalized(entry.getKey())))
+                if (configKeys.contains(toLowerCaseLocalized(entry.getKey())))
                 {
-                    throw new IllegalArgumentException("SslContextFactory "+ssl_context_factory.class_name+" should " +
-                                                       "configure '"+entry.getKey()+"' as encryption_options instead of" +
+                    throw new IllegalArgumentException("SslContextFactory " + ssl_context_factory.class_name + " should " +
+                                                       "configure '" + entry.getKey() + "' as encryption_options instead of" +
                                                        " parameterized keys");
                 }
-                sslContextFactoryParameters.put(entry.getKey(),entry.getValue());
+                sslContextFactoryParameters.put(entry.getKey(), entry.getValue());
             }
         }
     }
@@ -374,7 +336,8 @@ public class EncryptionOptions
 
     protected static void putSslContextFactoryParameter(Map<String, Object> existingParameters, ConfigKey configKey, Object value)
     {
-        if (value != null) {
+        if (value != null)
+        {
             existingParameters.put(configKey.toString(), value);
         }
     }
@@ -479,9 +442,9 @@ public class EncryptionOptions
         return sslContextFactoryInstance == null ? null : sslContextFactoryInstance.getAcceptedProtocols();
     }
 
-    public ClientAuth getClientAuth()
+    public ClientEncryptionOptions.ClientAuth getClientAuth()
     {
-        return this.require_client_auth == null ? ClientAuth.NOT_REQUIRED : ClientAuth.from(this.require_client_auth);
+        return this.require_client_auth == null ? ClientEncryptionOptions.ClientAuth.NOT_REQUIRED : ClientEncryptionOptions.ClientAuth.from(this.require_client_auth);
     }
 
     public String[] acceptedProtocolsArray()
@@ -516,182 +479,6 @@ public class EncryptionOptions
         }
     }
 
-    public static class Builder
-    {
-        private ParameterizedClass ssl_context_factory;
-        private String keystore;
-        private String keystore_password;
-        private String keystore_password_file;
-        private String truststore;
-        private String truststore_password;
-        private String truststore_password_file;
-        private List<String> cipher_suites;
-        private String protocol;
-        private List<String> accepted_protocols;
-        private String algorithm;
-        private String store_type;
-        private String require_client_auth;
-        private boolean require_endpoint_verification;
-        private DurationSpec.IntMinutesBound max_certificate_validity_period;
-        private DurationSpec.IntMinutesBound certificate_validity_warn_threshold;
-        private Boolean enabled;
-        private Boolean optional;
-        private Boolean isEnabled;
-        private Boolean isOptional;
-
-        private EncryptionOptions encryptionOptions;
-
-        public Builder()
-        {
-            this(new EncryptionOptions());
-        }
-
-        public Builder(EncryptionOptions options)
-        {
-            ssl_context_factory = options.ssl_context_factory;
-            keystore = options.keystore;
-            keystore_password = options.keystore_password;
-            keystore_password_file = options.keystore_password_file;
-            truststore = options.truststore;
-            truststore_password = options.truststore_password;
-            truststore_password_file = options.truststore_password_file;
-            cipher_suites = options.cipher_suites;
-            protocol = options.protocol;
-            accepted_protocols = options.accepted_protocols;
-            algorithm = options.algorithm;
-            store_type = options.store_type;
-            require_client_auth = options.require_client_auth;
-            require_endpoint_verification = options.require_endpoint_verification;
-            enabled = options.enabled;
-            optional = options.optional;
-            max_certificate_validity_period = options.max_certificate_validity_period;
-            certificate_validity_warn_threshold = options.certificate_validity_warn_threshold;
-        }
-
-        public Builder withSslContextFactory(ParameterizedClass sslContextFactoryClass)
-        {
-            this.ssl_context_factory = sslContextFactoryClass;
-            return this;
-        }
-
-        public Builder withKeyStore(String keystore)
-        {
-            this.keystore = keystore;
-            return this;
-        }
-
-        public Builder withKeyStorePassword(String keystore_password)
-        {
-            this.keystore_password = keystore_password;
-            return this;
-        }
-
-        public Builder withKeyStorePasswordFile(String keystore_password_file)
-        {
-            this.keystore_password_file = keystore_password_file;
-            return this;
-        }
-
-        public Builder withTrustStore(String truststore)
-        {
-            this.truststore = truststore;
-            return this;
-        }
-
-        public Builder withTrustStorePassword(String truststore_password)
-        {
-            this.truststore_password = truststore_password;
-            return this;
-        }
-
-        public Builder withTrustStorePasswordFile(String truststore_password_file)
-        {
-            this.truststore_password_file = truststore_password_file;
-            return this;
-        }
-
-        public Builder withCipherSuites(List<String> cipher_suites)
-        {
-            this.cipher_suites = cipher_suites;
-            return this;
-        }
-
-        public Builder withCipherSuites(String... cipher_suites)
-        {
-            this.cipher_suites = ImmutableList.copyOf(cipher_suites);
-            return this;
-        }
-
-        public Builder withProtocol(String protocol)
-        {
-            this.protocol = protocol;
-            return this;
-        }
-
-        public Builder withAcceptedProtocols(List<String> accepted_protocols)
-        {
-            this.accepted_protocols = accepted_protocols == null ? null :
-                                      ImmutableList.copyOf(accepted_protocols);
-            return this;
-        }
-
-        public Builder withAlgorithm(String algorithm)
-        {
-            this.algorithm = algorithm;
-            return this;
-        }
-
-        public Builder withStoreType(String store_type)
-        {
-            this.store_type = store_type;
-            return this;
-        }
-
-        public Builder withRequireClientAuth(ClientAuth require_client_auth)
-        {
-            this.require_client_auth = require_client_auth.value;
-            return this;
-        }
-
-        public Builder withRequireEndpointVerification(boolean require_endpoint_verification)
-        {
-            this.require_endpoint_verification = require_endpoint_verification;
-            return this;
-        }
-
-        public Builder withEnabled(boolean enabled)
-        {
-            this.enabled = enabled;
-            return this;
-        }
-
-        public Builder withOptional(Boolean optional)
-        {
-            this.optional = optional;
-            return this;
-        }
-
-        public Builder withMaxCertificateValidityPeriod(DurationSpec.IntMinutesBound maxCertificateValidityPeriod)
-        {
-            this.max_certificate_validity_period = maxCertificateValidityPeriod;
-            return this;
-        }
-
-        public Builder withCertificateValidityWarnThreshold(DurationSpec.IntMinutesBound certificateValidityWarnThreshold)
-        {
-            this.certificate_validity_warn_threshold = certificateValidityWarnThreshold;
-            return this;
-        }
-
-        public EncryptionOptions build()
-        {
-            return new EncryptionOptions(ssl_context_factory, keystore, keystore_password, keystore_password_file, truststore,
-                                         truststore_password, truststore_password_file, cipher_suites, protocol, accepted_protocols, algorithm,
-                                         store_type, require_client_auth, require_endpoint_verification, enabled,
-                                         optional, max_certificate_validity_period, certificate_validity_warn_threshold).applyConfig();
-        }
-    }
-
     /**
      * The method is being mainly used to cache SslContexts therefore, we only consider
      * fields that would make a difference when the TrustStore or KeyStore files are updated
@@ -704,7 +491,7 @@ public class EncryptionOptions
         if (o == null || getClass() != o.getClass())
             return false;
 
-        EncryptionOptions opt = (EncryptionOptions)o;
+        EncryptionOptions opt = (EncryptionOptions) o;
         return enabled == opt.enabled &&
                optional == opt.optional &&
                require_client_auth.equals(opt.require_client_auth) &&
@@ -750,8 +537,253 @@ public class EncryptionOptions
         return result;
     }
 
-    public static class ServerEncryptionOptions extends EncryptionOptions
+    public static abstract class Builder<T extends EncryptionOptions<T>>
     {
+        ParameterizedClass ssl_context_factory;
+        String keystore;
+        String keystore_password;
+        String keystore_password_file;
+        String truststore;
+        String truststore_password;
+        String truststore_password_file;
+        List<String> cipher_suites;
+        String protocol;
+        List<String> accepted_protocols;
+        String algorithm;
+        String store_type;
+        String require_client_auth;
+        boolean require_endpoint_verification;
+        DurationSpec.IntMinutesBound max_certificate_validity_period;
+        DurationSpec.IntMinutesBound certificate_validity_warn_threshold;
+        Boolean enabled;
+        Boolean optional;
+        Boolean isEnabled;
+        Boolean isOptional;
+
+        public Builder(EncryptionOptions<T> options)
+        {
+            ssl_context_factory = options.ssl_context_factory;
+            keystore = options.keystore;
+            keystore_password = options.keystore_password;
+            keystore_password_file = options.keystore_password_file;
+            truststore = options.truststore;
+            truststore_password = options.truststore_password;
+            truststore_password_file = options.truststore_password_file;
+            cipher_suites = options.cipher_suites;
+            protocol = options.protocol;
+            accepted_protocols = options.accepted_protocols;
+            algorithm = options.algorithm;
+            store_type = options.store_type;
+            require_client_auth = options.require_client_auth;
+            require_endpoint_verification = options.require_endpoint_verification;
+            enabled = options.enabled;
+            optional = options.optional;
+            max_certificate_validity_period = options.max_certificate_validity_period;
+            certificate_validity_warn_threshold = options.certificate_validity_warn_threshold;
+        }
+
+        public Builder<T> withSslContextFactory(ParameterizedClass sslContextFactoryClass)
+        {
+            this.ssl_context_factory = sslContextFactoryClass;
+            return this;
+        }
+
+        public Builder<T> withKeyStore(String keystore)
+        {
+            this.keystore = keystore;
+            return this;
+        }
+
+        public Builder<T> withKeyStorePassword(String keystore_password)
+        {
+            this.keystore_password = keystore_password;
+            return this;
+        }
+
+        public Builder<T> withKeyStorePasswordFile(String keystore_password_file)
+        {
+            this.keystore_password_file = keystore_password_file;
+            return this;
+        }
+
+        public Builder<T> withTrustStore(String truststore)
+        {
+            this.truststore = truststore;
+            return this;
+        }
+
+        public Builder<T> withTrustStorePassword(String truststore_password)
+        {
+            this.truststore_password = truststore_password;
+            return this;
+        }
+
+        public Builder<T> withTrustStorePasswordFile(String truststore_password_file)
+        {
+            this.truststore_password_file = truststore_password_file;
+            return this;
+        }
+
+        public Builder<T> withCipherSuites(List<String> cipher_suites)
+        {
+            this.cipher_suites = cipher_suites;
+            return this;
+        }
+
+        public Builder<T> withCipherSuites(String... cipher_suites)
+        {
+            this.cipher_suites = ImmutableList.copyOf(cipher_suites);
+            return this;
+        }
+
+        public Builder<T> withProtocol(String protocol)
+        {
+            this.protocol = protocol;
+            return this;
+        }
+
+        public Builder<T> withAcceptedProtocols(List<String> accepted_protocols)
+        {
+            this.accepted_protocols = accepted_protocols == null ? null :
+                                      ImmutableList.copyOf(accepted_protocols);
+            return this;
+        }
+
+        public Builder<T> withAlgorithm(String algorithm)
+        {
+            this.algorithm = algorithm;
+            return this;
+        }
+
+        public Builder<T> withStoreType(String store_type)
+        {
+            this.store_type = store_type;
+            return this;
+        }
+
+        public Builder<T> withRequireClientAuth(ClientEncryptionOptions.ClientAuth require_client_auth)
+        {
+            this.require_client_auth = require_client_auth.value;
+            return this;
+        }
+
+        public Builder<T> withRequireEndpointVerification(boolean require_endpoint_verification)
+        {
+            this.require_endpoint_verification = require_endpoint_verification;
+            return this;
+        }
+
+        public Builder<T> withEnabled(boolean enabled)
+        {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder<T> withOptional(Boolean optional)
+        {
+            this.optional = optional;
+            return this;
+        }
+
+        public Builder<T> withMaxCertificateValidityPeriod(DurationSpec.IntMinutesBound maxCertificateValidityPeriod)
+        {
+            this.max_certificate_validity_period = maxCertificateValidityPeriod;
+            return this;
+        }
+
+        public Builder<T> withCertificateValidityWarnThreshold(DurationSpec.IntMinutesBound certificateValidityWarnThreshold)
+        {
+            this.certificate_validity_warn_threshold = certificateValidityWarnThreshold;
+            return this;
+        }
+
+        public abstract T build();
+    }
+
+    public static class ClientEncryptionOptions extends EncryptionOptions<ClientEncryptionOptions>
+    {
+        public ClientEncryptionOptions()
+        {
+        }
+
+        public ClientEncryptionOptions(ParameterizedClass ssl_context_factory,
+                                       String keystore, String keystore_password, String keystore_password_file,
+                                       String truststore, String truststore_password, String truststore_password_file,
+                                       List<String> cipher_suites, String protocol, List<String> accepted_protocols,
+                                       String algorithm, String store_type, String require_client_auth,
+                                       boolean require_endpoint_verification, Boolean enabled, Boolean optional,
+                                       DurationSpec.IntMinutesBound max_certificate_validity_period,
+                                       DurationSpec.IntMinutesBound certificate_validity_warn_threshold)
+        {
+            super(ssl_context_factory, keystore, keystore_password, keystore_password_file, truststore, truststore_password,
+                  truststore_password_file, cipher_suites, protocol, accepted_protocols, algorithm, store_type, require_client_auth,
+                  require_endpoint_verification, enabled, optional, max_certificate_validity_period, certificate_validity_warn_threshold);
+        }
+
+        public enum ClientAuth
+        {
+            REQUIRED("true"),
+            NOT_REQUIRED("false"),
+            OPTIONAL("optional");
+            private final String value;
+            private static final Map<String, ClientAuth> VALUES = new HashMap<>();
+
+            static
+            {
+                for (ClientAuth clientAuth : ClientAuth.values())
+                {
+                    VALUES.put(clientAuth.value, clientAuth);
+                    VALUES.put(toLowerCaseLocalized(clientAuth.name()), clientAuth);
+                }
+            }
+
+            ClientAuth(String value)
+            {
+                this.value = value;
+            }
+
+            public static ClientAuth from(String value)
+            {
+                if (VALUES.containsKey(toLowerCaseLocalized(value)))
+                {
+                    return VALUES.get(toLowerCaseLocalized(value));
+                }
+                throw new ConfigurationException(value + " is not a valid ClientAuth option");
+            }
+
+            public String value()
+            {
+                return value;
+            }
+        }
+
+        public static class Builder extends EncryptionOptions.Builder<ClientEncryptionOptions>
+        {
+            public Builder()
+            {
+                this(new ClientEncryptionOptions());
+            }
+
+            public Builder(ClientEncryptionOptions options)
+            {
+                super(options);
+            }
+
+            @Override
+            public ClientEncryptionOptions build()
+            {
+                return new ClientEncryptionOptions(ssl_context_factory, keystore, keystore_password, keystore_password_file, truststore,
+                                                   truststore_password, truststore_password_file, cipher_suites, protocol, accepted_protocols, algorithm,
+                                                   store_type, require_client_auth, require_endpoint_verification, enabled,
+                                                   optional, max_certificate_validity_period, certificate_validity_warn_threshold).applyConfig();
+            }
+        }
+    }
+
+    public static class ServerEncryptionOptions extends EncryptionOptions<ServerEncryptionOptions>
+    {
+        private static final Logger logger = LoggerFactory.getLogger(ServerEncryptionOptions.class);
+
         public enum InternodeEncryption
         {
             all, none, dc, rack
@@ -781,7 +813,7 @@ public class EncryptionOptions
                                        String truststore, String truststore_password, String truststore_password_file,
                                        List<String> cipher_suites, String protocol, List<String> accepted_protocols,
                                        String algorithm, String store_type, String require_client_auth,
-                                       boolean require_endpoint_verification, Boolean optional,
+                                       boolean require_endpoint_verification, Boolean enabled, Boolean optional,
                                        InternodeEncryption internode_encryption, boolean legacy_ssl_storage_port_enabled,
                                        DurationSpec.IntMinutesBound maxCertificateAgeMinutes,
                                        DurationSpec.IntMinutesBound certificateValidityWarnThreshold)
@@ -789,7 +821,7 @@ public class EncryptionOptions
             super(sslContextFactoryClass, keystore, keystore_password, keystore_password_file,
                   truststore, truststore_password, truststore_password_file, cipher_suites,
                   protocol, accepted_protocols, algorithm, store_type, require_client_auth, require_endpoint_verification,
-                  null, optional, maxCertificateAgeMinutes, certificateValidityWarnThreshold);
+                  enabled, optional, maxCertificateAgeMinutes, certificateValidityWarnThreshold);
             this.internode_encryption = internode_encryption;
             this.legacy_ssl_storage_port_enabled = legacy_ssl_storage_port_enabled;
             this.outbound_keystore = outbound_keystore;
@@ -807,7 +839,7 @@ public class EncryptionOptions
             this.outbound_keystore_password_file = options.outbound_keystore_password_file;
         }
 
-        public static class Builder extends EncryptionOptions.Builder
+        public static class Builder extends EncryptionOptions.Builder<ServerEncryptionOptions>
         {
             private InternodeEncryption internode_encryption;
             private boolean legacy_ssl_storage_port_enabled;
@@ -828,108 +860,6 @@ public class EncryptionOptions
                 this.outbound_keystore = options.outbound_keystore;
                 this.outbound_keystore_password = options.outbound_keystore_password;
                 this.outbound_keystore_password_file = options.outbound_keystore_password_file;
-            }
-
-            public Builder withSslContextFactory(ParameterizedClass sslContextFactoryClass)
-            {
-                super.withSslContextFactory(sslContextFactoryClass);
-                return this;
-            }
-
-            public Builder withKeyStore(String keystore)
-            {
-                super.withKeyStore(keystore);
-                return this;
-            }
-
-            public Builder withKeyStorePassword(String keystore_password)
-            {
-                super.withKeyStorePassword(keystore_password);
-                return this;
-            }
-
-            public Builder withKeyStorePasswordFile(String keystore_password_file)
-            {
-                super.withKeyStorePasswordFile(keystore_password_file);
-                return this;
-            }
-
-            public Builder withTrustStore(String truststore)
-            {
-                super.withTrustStore(truststore);
-                return this;
-            }
-
-            public Builder withTrustStorePassword(String truststore_password)
-            {
-                super.withTrustStorePassword(truststore_password);
-                return this;
-            }
-
-            public Builder withTrustStorePasswordFile(String truststore_password_file)
-            {
-                super.withTrustStorePasswordFile(truststore_password_file);
-                return this;
-            }
-
-            public Builder withCipherSuites(List<String> cipher_suites)
-            {
-                super.withCipherSuites(cipher_suites);
-                return this;
-            }
-
-            public Builder withCipherSuites(String... cipher_suites)
-            {
-                super.withCipherSuites(cipher_suites);
-                return this;
-            }
-
-            public Builder withProtocol(String protocol)
-            {
-                super.withProtocol(protocol);
-                return this;
-            }
-
-            public Builder withAcceptedProtocols(List<String> accepted_protocols)
-            {
-                super.withAcceptedProtocols(accepted_protocols);
-                return this;
-            }
-
-            public Builder withAlgorithm(String algorithm)
-            {
-                super.withAlgorithm(algorithm);
-                return this;
-            }
-
-            public Builder withStoreType(String store_type)
-            {
-                super.withStoreType(store_type);
-                return this;
-            }
-
-            public Builder withRequireClientAuth(ClientAuth require_client_auth)
-            {
-                super.withRequireClientAuth(require_client_auth);
-                return this;
-            }
-
-            public Builder withRequireEndpointVerification(boolean require_endpoint_verification)
-            {
-                super.withRequireEndpointVerification(require_endpoint_verification);
-                return this;
-            }
-
-            public Builder withEnabled(boolean enabled)
-            {
-                super.withEnabled(enabled);
-                return this;
-            }
-
-            public Builder withOptional(Boolean optional)
-            {
-                super.withOptional(optional);
-                return this;
             }
 
             public Builder withInternodeEncryption(InternodeEncryption internode_encryption)
@@ -962,16 +892,17 @@ public class EncryptionOptions
                 return this;
             }
 
+            @Override
             public ServerEncryptionOptions build()
             {
-                return new ServerEncryptionOptions(super.ssl_context_factory, super.keystore, super.keystore_password, super.keystore_password_file,
+                return new ServerEncryptionOptions(ssl_context_factory, keystore, keystore_password, keystore_password_file,
                                                    outbound_keystore, outbound_keystore_password, outbound_keystore_password_file,
-                                                   super.truststore, super.truststore_password, super.truststore_password_file,
-                                                   super.cipher_suites, super.protocol, super.accepted_protocols,
-                                                   super.algorithm, super.store_type, super.require_client_auth,
-                                                   super.require_endpoint_verification, super.optional, internode_encryption,
-                                                   legacy_ssl_storage_port_enabled, super.max_certificate_validity_period,
-                                                   super.certificate_validity_warn_threshold).applyConfigInternal();
+                                                   truststore, truststore_password, truststore_password_file,
+                                                   cipher_suites, protocol, accepted_protocols,
+                                                   algorithm, store_type, require_client_auth,
+                                                   require_endpoint_verification, enabled, optional, internode_encryption,
+                                                   legacy_ssl_storage_port_enabled, max_certificate_validity_period,
+                                                   certificate_validity_warn_threshold).applyConfig();
             }
         }
 
@@ -985,7 +916,7 @@ public class EncryptionOptions
         }
 
         @Override
-        public EncryptionOptions applyConfig()
+        public ServerEncryptionOptions applyConfig()
         {
             return applyConfigInternal();
         }
@@ -1001,13 +932,13 @@ public class EncryptionOptions
                 logger.warn("Setting server_encryption_options.enabled has no effect, use internode_encryption");
             }
 
-            if (getClientAuth() != ClientAuth.NOT_REQUIRED && (internode_encryption == InternodeEncryption.rack || internode_encryption == InternodeEncryption.dc))
+            if (getClientAuth() != ClientEncryptionOptions.ClientAuth.NOT_REQUIRED && (internode_encryption == InternodeEncryption.rack || internode_encryption == InternodeEncryption.dc))
             {
                 logger.warn("Setting require_client_auth is incompatible with 'rack' and 'dc' internode_encryption values."
-                          + " It is possible for an internode connection to pretend to be in the same rack/dc by spoofing"
-                          + " its broadcast address in the handshake and bypass authentication. To ensure that mutual TLS"
-                          + " authentication is not bypassed, please set internode_encryption to 'all'. Continuing with"
-                          + " insecure configuration.");
+                            + " It is possible for an internode connection to pretend to be in the same rack/dc by spoofing"
+                            + " its broadcast address in the handshake and bypass authentication. To ensure that mutual TLS"
+                            + " authentication is not bypassed, please set internode_encryption to 'all'. Continuing with"
+                            + " insecure configuration.");
             }
 
             // regardless of the optional flag, if the internode encryption is set to rack or dc

--- a/src/java/org/apache/cassandra/config/JMXServerOptions.java
+++ b/src/java/org/apache/cassandra/config/JMXServerOptions.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.config;
 
-import java.util.HashMap;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -52,7 +51,7 @@ public class JMXServerOptions
     public final Boolean authenticate;
 
     // ssl options
-    public final EncryptionOptions jmx_encryption_options;
+    public final EncryptionOptions.ClientEncryptionOptions jmx_encryption_options;
 
     // options for using Cassandra's own authentication mechanisms
     public final String login_config_name;
@@ -71,11 +70,11 @@ public class JMXServerOptions
     public JMXServerOptions()
     {
         this(true, false, 7199, 0, false,
-             new EncryptionOptions(), null, null, null,
+             new EncryptionOptions.ClientEncryptionOptions(), null, null, null,
              null, null);
     }
 
-    public static JMXServerOptions create(boolean enabled, boolean local, int jmxPort, EncryptionOptions options)
+    public static JMXServerOptions create(boolean enabled, boolean local, int jmxPort, EncryptionOptions.ClientEncryptionOptions options)
     {
         return new JMXServerOptions(enabled, !local, jmxPort, 0, false,
                                     options, null, null, null,
@@ -95,7 +94,7 @@ public class JMXServerOptions
                             int jmxPort,
                             int rmiPort,
                             Boolean authenticate,
-                            EncryptionOptions jmx_encryption_options,
+                            EncryptionOptions.ClientEncryptionOptions jmx_encryption_options,
                             String loginConfigName,
                             String loginConfigFile,
                             String passwordFile,
@@ -198,27 +197,22 @@ public class JMXServerOptions
         // in the `cassandra.yaml`. Since the JMX SSL Config can also leverage it as per CASSANDRA-18508, password file
         // support is not added to the JMX SSL configuration via the system properties. Hence, `null` is used as
         // the password file arguments for the keystore and the truststore while constructing the encryption options here.
-        EncryptionOptions encryptionOptions = new EncryptionOptions(new ParameterizedClass("org.apache.cassandra.security.DefaultSslContextFactory", new HashMap<>()),
-                                                                    keystore,
-                                                                    keystorePassword,
-                                                                    null,
-                                                                    truststore,
-                                                                    truststorePassword,
-                                                                    null,
-                                                                    cipherSuites,
-                                                                    null, // protocol
-                                                                    acceptedProtocols,
-                                                                    null, // algorithm
-                                                                    null, // store_type
-                                                                    requireClientAuth,
-                                                                    false, // require endpoint verification
-                                                                    sslEnabled,
-                                                                    false, // optional
-                                                                    null, // max_certificate_validity_period
-                                                                    null); // certificate_validity_warn_threshold
+
+        EncryptionOptions.ClientEncryptionOptions options = new EncryptionOptions.ClientEncryptionOptions.Builder()
+                                                            .withKeyStore(keystore)
+                                                            .withKeyStorePassword(keystorePassword)
+                                                            .withTrustStore(truststore)
+                                                            .withTrustStorePassword(truststorePassword)
+                                                            .withCipherSuites(cipherSuites)
+                                                            .withAcceptedProtocols(acceptedProtocols)
+                                                            .withRequireClientAuth(EncryptionOptions.ClientEncryptionOptions.ClientAuth.from(requireClientAuth))
+                                                            .withRequireEndpointVerification(false)
+                                                            .withEnabled(sslEnabled)
+                                                            .withOptional(false)
+                                                            .build();
 
         return new JMXServerOptions(enabled, remote, jmxPort, rmiPort, authenticate,
-                                    encryptionOptions, loginConfigName, loginConfigFile, passwordFile, accessFile,
+                                    options, loginConfigName, loginConfigFile, passwordFile, accessFile,
                                     authorizer);
     }
 

--- a/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/InboundConnectionInitiator.java
@@ -64,7 +64,7 @@ import static java.lang.Math.*;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.cassandra.auth.IInternodeAuthenticator.InternodeConnectionDirection.INBOUND;
 import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFactory;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.apache.cassandra.net.InternodeConnectionUtils.DISCARD_HANDLER_NAME;
 import static org.apache.cassandra.net.InternodeConnectionUtils.SSL_FACTORY_CONTEXT_DESCRIPTION;
 import static org.apache.cassandra.net.InternodeConnectionUtils.SSL_HANDLER_NAME;
@@ -523,7 +523,7 @@ public class InboundConnectionInitiator
 
     private static SslHandler getSslHandler(String description, Channel channel, EncryptionOptions.ServerEncryptionOptions encryptionOptions) throws IOException
     {
-        final EncryptionOptions.ClientAuth verifyPeerCertificate = REQUIRED;
+        final EncryptionOptions.ClientEncryptionOptions.ClientAuth verifyPeerCertificate = REQUIRED;
         SslContext sslContext = SSLFactory.getOrCreateSslContext(encryptionOptions, verifyPeerCertificate,
                                                                  ISslContextFactory.SocketType.SERVER,
                                                                  SSL_FACTORY_CONTEXT_DESCRIPTION);

--- a/src/java/org/apache/cassandra/net/InboundConnectionSettings.java
+++ b/src/java/org/apache/cassandra/net/InboundConnectionSettings.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import org.apache.cassandra.auth.IInternodeAuthenticator;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions;
-import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions.Builder;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.utils.FBUtilities;
@@ -147,7 +146,7 @@ public class InboundConnectionSettings
         ServerEncryptionOptions encryption = this.encryption;
         if (encryption == null)
             encryption = DatabaseDescriptor.getInternodeMessagingEncyptionOptions();
-        encryption = new Builder(encryption).withOptional(false).withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all).build();
+        encryption = new ServerEncryptionOptions.Builder(encryption).withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all).withOptional(false).build();
 
         return this.withBindAddress(bindAddress.withPort(DatabaseDescriptor.getSSLStoragePort()))
                    .withEncryption(encryption)

--- a/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
+++ b/src/java/org/apache/cassandra/net/OutboundConnectionInitiator.java
@@ -66,9 +66,9 @@ import org.apache.cassandra.utils.memory.BufferPools;
 import static java.util.concurrent.TimeUnit.*;
 import static org.apache.cassandra.auth.IInternodeAuthenticator.InternodeConnectionDirection.OUTBOUND;
 import static org.apache.cassandra.auth.IInternodeAuthenticator.InternodeConnectionDirection.OUTBOUND_PRECONNECT;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.OPTIONAL;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.OPTIONAL;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.apache.cassandra.net.InternodeConnectionUtils.DISCARD_HANDLER_NAME;
 import static org.apache.cassandra.net.InternodeConnectionUtils.SSL_FACTORY_CONTEXT_DESCRIPTION;
 import static org.apache.cassandra.net.InternodeConnectionUtils.SSL_HANDLER_NAME;
@@ -245,7 +245,7 @@ public class OutboundConnectionInitiator<SuccessType extends OutboundConnectionI
 
         private SslContext getSslContext(SslFallbackConnectionType connectionType) throws IOException
         {
-            EncryptionOptions.ClientAuth requireClientAuth = NOT_REQUIRED;
+            EncryptionOptions.ClientEncryptionOptions.ClientAuth requireClientAuth = NOT_REQUIRED;
             if (connectionType == SslFallbackConnectionType.MTLS )
             {
                 requireClientAuth = REQUIRED;

--- a/src/java/org/apache/cassandra/security/AbstractSslContextFactory.java
+++ b/src/java/org/apache/cassandra/security/AbstractSslContextFactory.java
@@ -37,8 +37,8 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import org.apache.cassandra.config.EncryptionOptions;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_TCACTIVE_OPENSSL;
 
@@ -68,7 +68,7 @@ abstract public class AbstractSslContextFactory implements ISslContextFactory
     protected final List<String> accepted_protocols;
     protected final String algorithm;
     protected final String store_type;
-    protected final EncryptionOptions.ClientAuth clientAuth;
+    protected final EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth;
     protected final boolean require_endpoint_verification;
     /*
     ServerEncryptionOptions does not use the enabled flag at all instead using the existing
@@ -105,7 +105,7 @@ abstract public class AbstractSslContextFactory implements ISslContextFactory
         accepted_protocols = getStringList("accepted_protocols");
         algorithm = getString("algorithm");
         store_type = getString("store_type", "JKS");
-        clientAuth = parameters.get("require_client_auth") == null ? NOT_REQUIRED : EncryptionOptions.ClientAuth.from(getString("require_client_auth"));
+        clientAuth = parameters.get("require_client_auth") == null ? NOT_REQUIRED : EncryptionOptions.ClientEncryptionOptions.ClientAuth.from(getString("require_client_auth"));
         require_endpoint_verification = getBoolean("require_endpoint_verification", false);
         enabled = getBoolean("enabled");
         optional = getBoolean("optional");
@@ -158,7 +158,7 @@ abstract public class AbstractSslContextFactory implements ISslContextFactory
     }
 
     @Override
-    public SSLContext createJSSESslContext(EncryptionOptions.ClientAuth clientAuth) throws SSLException
+    public SSLContext createJSSESslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth) throws SSLException
     {
         TrustManager[] trustManagers = null;
         if (clientAuth != NOT_REQUIRED)
@@ -186,7 +186,7 @@ abstract public class AbstractSslContextFactory implements ISslContextFactory
     }
 
     @Override
-    public SslContext createNettySslContext(EncryptionOptions.ClientAuth clientAuth, SocketType socketType,
+    public SslContext createNettySslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth, SocketType socketType,
                                             CipherSuiteFilter cipherFilter) throws SSLException
     {
         /*
@@ -291,7 +291,7 @@ abstract public class AbstractSslContextFactory implements ISslContextFactory
      */
     abstract protected KeyManagerFactory buildOutboundKeyManagerFactory() throws SSLException;
 
-    private ClientAuth toNettyClientAuth(EncryptionOptions.ClientAuth clientAuth)
+    private ClientAuth toNettyClientAuth(EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth)
     {
         switch (clientAuth)
         {

--- a/src/java/org/apache/cassandra/security/ISslContextFactory.java
+++ b/src/java/org/apache/cassandra/security/ISslContextFactory.java
@@ -72,7 +72,7 @@ public interface ISslContextFactory
      * @return JSSE's {@link SSLContext}
      * @throws SSLException in case the Ssl Context creation fails for some reason
      */
-    default SSLContext createJSSESslContext(EncryptionOptions.ClientAuth clientAuth) throws SSLException
+    default SSLContext createJSSESslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth) throws SSLException
     {
         switch (clientAuth)
         {
@@ -112,7 +112,7 @@ public interface ISslContextFactory
      * @return Netty's {@link SslContext}
      * @throws SSLException in case the Ssl Context creation fails for some reason
      */
-    default SslContext createNettySslContext(EncryptionOptions.ClientAuth clientAuth, SocketType socketType,
+    default SslContext createNettySslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth, SocketType socketType,
                                              CipherSuiteFilter cipherFilter) throws SSLException
     {
         switch (clientAuth)

--- a/src/java/org/apache/cassandra/security/SSLFactory.java
+++ b/src/java/org/apache/cassandra/security/SSLFactory.java
@@ -47,7 +47,7 @@ import org.apache.cassandra.security.ISslContextFactory.SocketType;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_TCACTIVE_OPENSSL;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.apache.cassandra.utils.LocalizeString.toLowerCaseLocalized;
 
 /**
@@ -125,7 +125,7 @@ public final class SSLFactory
     /**
      * Create a JSSE {@link SSLContext}.
      */
-    public static SSLContext createSSLContext(EncryptionOptions options, EncryptionOptions.ClientAuth clientAuth) throws IOException
+    public static SSLContext createSSLContext(EncryptionOptions options, EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth) throws IOException
     {
         return options.sslContextFactoryInstance.createJSSESslContext(clientAuth);
     }
@@ -133,7 +133,7 @@ public final class SSLFactory
     /**
      * get a netty {@link SslContext} instance
      */
-    public static SslContext getOrCreateSslContext(EncryptionOptions options, EncryptionOptions.ClientAuth clientAuth,
+    public static SslContext getOrCreateSslContext(EncryptionOptions options, EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth,
                                                    SocketType socketType,
                                                    String contextDescription) throws IOException
     {
@@ -157,7 +157,7 @@ public final class SSLFactory
     /**
      * Create a Netty {@link SslContext}
      */
-    static SslContext createNettySslContext(EncryptionOptions options, EncryptionOptions.ClientAuth clientAuth,
+    static SslContext createNettySslContext(EncryptionOptions options, EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth,
                                             SocketType socketType) throws IOException
     {
         return createNettySslContext(options, clientAuth, socketType,
@@ -167,7 +167,7 @@ public final class SSLFactory
     /**
      * Create a Netty {@link SslContext} with a supplied cipherFilter
      */
-    static SslContext createNettySslContext(EncryptionOptions options, EncryptionOptions.ClientAuth clientAuth,
+    static SslContext createNettySslContext(EncryptionOptions options, EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth,
                                             SocketType socketType, CipherSuiteFilter cipherFilter) throws IOException
     {
         return options.sslContextFactoryInstance.createNettySslContext(clientAuth, socketType,
@@ -356,7 +356,7 @@ public final class SSLFactory
         return !string.equals("SSLv2Hello");
     }
 
-    public static void validateSslContext(String contextDescription, EncryptionOptions options, EncryptionOptions.ClientAuth clientAuth, boolean logProtocolAndCiphers) throws IOException
+    public static void validateSslContext(String contextDescription, EncryptionOptions options, EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth, boolean logProtocolAndCiphers) throws IOException
     {
         if (options != null && options.tlsEncryptionPolicy() != EncryptionOptions.TlsEncryptionPolicy.UNENCRYPTED)
         {

--- a/src/java/org/apache/cassandra/tools/BulkLoader.java
+++ b/src/java/org/apache/cassandra/tools/BulkLoader.java
@@ -48,7 +48,7 @@ import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.apache.cassandra.utils.NativeSSTableLoaderClient;
 import org.apache.cassandra.utils.OutputHandler;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.apache.cassandra.utils.Clock.Global.nanoTime;
 
 public class BulkLoader

--- a/src/java/org/apache/cassandra/tools/LoaderOptions.java
+++ b/src/java/org/apache/cassandra/tools/LoaderOptions.java
@@ -52,7 +52,7 @@ import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.tools.BulkLoader.CmdLineOptions;
 
 import static org.apache.cassandra.config.DataRateSpec.DataRateUnit.MEBIBYTES_PER_SECOND;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 
 public class LoaderOptions
 {
@@ -121,7 +121,7 @@ public class LoaderOptions
     public final int entireSSTableInterDcThrottleMebibytes;
     public final int storagePort;
     public final int sslStoragePort;
-    public final EncryptionOptions clientEncOptions;
+    public final EncryptionOptions.ClientEncryptionOptions clientEncOptions;
     public final int connectionsPerHost;
     public final EncryptionOptions.ServerEncryptionOptions serverEncOptions;
     public final Set<InetSocketAddress> hosts;
@@ -172,8 +172,8 @@ public class LoaderOptions
 
         int storagePort;
         int sslStoragePort;
-        EncryptionOptions clientEncOptions = new EncryptionOptions();
-        EncryptionOptions.Builder clientEncOptionsBuilder = new EncryptionOptions.Builder(clientEncOptions);
+        EncryptionOptions.ClientEncryptionOptions clientEncOptions = new EncryptionOptions.ClientEncryptionOptions();
+        EncryptionOptions.ClientEncryptionOptions.Builder clientEncOptionsBuilder = new EncryptionOptions.ClientEncryptionOptions.Builder(clientEncOptions);
         int connectionsPerHost = 1;
         EncryptionOptions.ServerEncryptionOptions serverEncOptions = new EncryptionOptions.ServerEncryptionOptions();
         EncryptionOptions.ServerEncryptionOptions.Builder serverEncOptionsBuilder = new EncryptionOptions.ServerEncryptionOptions.Builder(serverEncOptions);
@@ -335,10 +335,10 @@ public class LoaderOptions
             return this;
         }
 
-        public Builder encOptions(EncryptionOptions encOptions)
+        public Builder encOptions(EncryptionOptions.ClientEncryptionOptions encOptions)
         {
             this.clientEncOptions = encOptions;
-            this.clientEncOptionsBuilder = new EncryptionOptions.Builder(encOptions);
+            this.clientEncOptionsBuilder = new EncryptionOptions.ClientEncryptionOptions.Builder(encOptions);
             return this;
         }
 
@@ -555,7 +555,7 @@ public class LoaderOptions
                                 "which is able to handle encrypted communication too.");
 
                 // Copy the encryption options and apply the config so that argument parsing can accesss isEnabled.
-                clientEncOptionsBuilder = new EncryptionOptions.Builder(config.client_encryption_options);
+                clientEncOptionsBuilder = new EncryptionOptions.ClientEncryptionOptions.Builder(config.client_encryption_options);
                 clientEncOptions = clientEncOptionsBuilder.build();
                 serverEncOptionsBuilder = new EncryptionOptions.ServerEncryptionOptions.Builder(config.server_encryption_options);
                 serverEncOptions = serverEncOptionsBuilder.build();

--- a/src/java/org/apache/cassandra/transport/Client.java
+++ b/src/java/org/apache/cassandra/transport/Client.java
@@ -45,9 +45,9 @@ public class Client extends SimpleClient
 {
     private final SimpleEventHandler eventHandler = new SimpleEventHandler();
 
-    public Client(String host, int port, ProtocolVersion version, EncryptionOptions encryptionOptions)
+    public Client(String host, int port, ProtocolVersion version, EncryptionOptions.ClientEncryptionOptions encryptionOptions)
     {
-        super(host, port, version, version.isBeta(), new EncryptionOptions(encryptionOptions).applyConfig());
+        super(host, port, version, version.isBeta(), encryptionOptions.applyConfig());
         setEventHandler(eventHandler);
     }
 
@@ -260,7 +260,7 @@ public class Client extends SimpleClient
         int port = Integer.parseInt(args[1]);
         ProtocolVersion version = args.length == 3 ? ProtocolVersion.decode(Integer.parseInt(args[2]), DatabaseDescriptor.getNativeTransportAllowOlderProtocols()) : ProtocolVersion.CURRENT;
 
-        EncryptionOptions encryptionOptions = new EncryptionOptions().applyConfig();
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions = new EncryptionOptions.ClientEncryptionOptions().applyConfig();
         System.out.println("CQL binary protocol console " + host + "@" + port + " using native protocol version " + version);
 
         try (Client client = new Client(host, port, version, encryptionOptions))

--- a/src/java/org/apache/cassandra/transport/SimpleClient.java
+++ b/src/java/org/apache/cassandra/transport/SimpleClient.java
@@ -74,7 +74,7 @@ public class SimpleClient implements Closeable
 
     public final String host;
     public final int port;
-    private final EncryptionOptions encryptionOptions;
+    private final EncryptionOptions.ClientEncryptionOptions encryptionOptions;
     private final int largeMessageThreshold;
 
     protected final ResponseHandler responseHandler = new ResponseHandler();
@@ -92,7 +92,7 @@ public class SimpleClient implements Closeable
     {
         private final String host;
         private final int port;
-        private EncryptionOptions encryptionOptions = new EncryptionOptions();
+        private EncryptionOptions.ClientEncryptionOptions encryptionOptions = new EncryptionOptions.ClientEncryptionOptions();
         private ProtocolVersion version = ProtocolVersion.CURRENT;
         private boolean useBeta = false;
         private int largeMessageThreshold = FrameEncoder.Payload.MAX_SIZE;
@@ -103,7 +103,7 @@ public class SimpleClient implements Closeable
             this.port = port;
         }
 
-        public Builder encryption(EncryptionOptions options)
+        public Builder encryption(EncryptionOptions.ClientEncryptionOptions options)
         {
             this.encryptionOptions = options;
             return this;
@@ -149,22 +149,22 @@ public class SimpleClient implements Closeable
         this.largeMessageThreshold = builder.largeMessageThreshold;
     }
 
-    public SimpleClient(String host, int port, ProtocolVersion version, EncryptionOptions encryptionOptions)
+    public SimpleClient(String host, int port, ProtocolVersion version, EncryptionOptions.ClientEncryptionOptions encryptionOptions)
     {
         this(host, port, version, false, encryptionOptions);
     }
 
-    public SimpleClient(String host, int port, EncryptionOptions encryptionOptions)
+    public SimpleClient(String host, int port, EncryptionOptions.ClientEncryptionOptions encryptionOptions)
     {
         this(host, port, ProtocolVersion.CURRENT, encryptionOptions);
     }
 
     public SimpleClient(String host, int port, ProtocolVersion version)
     {
-        this(host, port, version, new EncryptionOptions());
+        this(host, port, version, new EncryptionOptions.ClientEncryptionOptions());
     }
 
-    public SimpleClient(String host, int port, ProtocolVersion version, boolean useBeta, EncryptionOptions encryptionOptions)
+    public SimpleClient(String host, int port, ProtocolVersion version, boolean useBeta, EncryptionOptions.ClientEncryptionOptions encryptionOptions)
     {
         this.host = host;
         this.port = port;
@@ -172,7 +172,7 @@ public class SimpleClient implements Closeable
             throw new IllegalArgumentException(String.format("Beta version of server used (%s), but USE_BETA flag is not set", version));
 
         this.version = version;
-        this.encryptionOptions = new EncryptionOptions(encryptionOptions).applyConfig();
+        this.encryptionOptions = encryptionOptions.applyConfig();
         this.largeMessageThreshold = FrameEncoder.Payload.MAX_SIZE -
                                         Math.max(FrameEncoderCrc.HEADER_AND_TRAILER_LENGTH,
                                                  FrameEncoderLZ4.HEADER_AND_TRAILER_LENGTH);
@@ -180,7 +180,7 @@ public class SimpleClient implements Closeable
 
     public SimpleClient(String host, int port)
     {
-        this(host, port, new EncryptionOptions());
+        this(host, port, new EncryptionOptions.ClientEncryptionOptions());
     }
 
     public SimpleClient connect(boolean useCompression) throws IOException

--- a/src/java/org/apache/cassandra/utils/jmx/AbstractJmxSocketFactory.java
+++ b/src/java/org/apache/cassandra/utils/jmx/AbstractJmxSocketFactory.java
@@ -82,7 +82,7 @@ abstract public class AbstractJmxSocketFactory
                 JMXServerOptions.setJmxSystemProperties(jmxEncryptionOptions.getAcceptedProtocols(), jmxEncryptionOptions.getCipherSuites());
 
             logger.info("Enabling JMX SSL using jmx_encryption_options");
-            boolean requireClientAuth = jmxEncryptionOptions.getClientAuth() == EncryptionOptions.ClientAuth.REQUIRED;
+            boolean requireClientAuth = jmxEncryptionOptions.getClientAuth() == EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
             String[] ciphers = jmxEncryptionOptions.cipherSuitesArray();
             String[] protocols = jmxEncryptionOptions.acceptedProtocolsArray();
             SSLContext sslContext = jmxEncryptionOptions.sslContextFactoryInstance.createJSSESslContext(jmxEncryptionOptions.getClientAuth());

--- a/test/burn/org/apache/cassandra/transport/SimpleClientBurnTest.java
+++ b/test/burn/org/apache/cassandra/transport/SimpleClientBurnTest.java
@@ -138,11 +138,11 @@ public class SimpleClientBurnTest
         Arrays.asList(
         () -> new SimpleClient(address.getHostAddress(),
                                port, ProtocolVersion.V5, true,
-                               new EncryptionOptions())
+                               new EncryptionOptions.ClientEncryptionOptions())
               .connect(false),
         () -> new SimpleClient(address.getHostAddress(),
                                port, ProtocolVersion.V4, false,
-                               new EncryptionOptions())
+                               new EncryptionOptions.ClientEncryptionOptions())
               .connect(false)
         );
 

--- a/test/burn/org/apache/cassandra/transport/SimpleClientPerfTest.java
+++ b/test/burn/org/apache/cassandra/transport/SimpleClientPerfTest.java
@@ -102,7 +102,7 @@ public class SimpleClientPerfTest
                  new SizeCaps(10, 20, 5, 10),
                  () -> new SimpleClient(address.getHostAddress(),
                                         port, version, true,
-                                        new EncryptionOptions())
+                                        new EncryptionOptions.ClientEncryptionOptions())
                        .connect(false),
                  version);
     }
@@ -114,7 +114,7 @@ public class SimpleClientPerfTest
                  new SizeCaps(10, 20, 5, 10),
                  () -> new SimpleClient(address.getHostAddress(),
                                         port, version, true,
-                                        new EncryptionOptions())
+                                        new EncryptionOptions.ClientEncryptionOptions())
                        .connect(true),
                  version);
     }
@@ -126,7 +126,7 @@ public class SimpleClientPerfTest
                  new SizeCaps(1000, 2000, 5, 150),
                  () -> new SimpleClient(address.getHostAddress(),
                                         port, version, true,
-                                        new EncryptionOptions())
+                                        new EncryptionOptions.ClientEncryptionOptions())
                        .connect(false),
                  version);
     }
@@ -138,7 +138,7 @@ public class SimpleClientPerfTest
                  new SizeCaps(1000, 2000, 5, 150),
                  () -> new SimpleClient(address.getHostAddress(),
                                         port, version, true,
-                                        new EncryptionOptions())
+                                        new EncryptionOptions.ClientEncryptionOptions())
                        .connect(true),
                  version);
     }

--- a/test/distributed/org/apache/cassandra/distributed/impl/IsolatedJmx.java
+++ b/test/distributed/org/apache/cassandra/distributed/impl/IsolatedJmx.java
@@ -93,7 +93,7 @@ public class IsolatedJmx
 
             // CASSANDRA-18508: Sensitive JMX SSL configuration options can be easily exposed
             Map<String, Object> jmxServerOptionsMap = (Map<String, Object>) config.getParams().get("jmx_server_options");
-            EncryptionOptions jmxEncryptionOptions;
+            EncryptionOptions.ClientEncryptionOptions jmxEncryptionOptions;
             if (jmxServerOptionsMap == null)
             {
                 JMXServerOptions parsingSystemProperties = JMXServerOptions.createParsingSystemProperties();
@@ -165,7 +165,7 @@ public class IsolatedJmx
      * @return EncryptionOptions built object
      */
     @SuppressWarnings("unchecked")
-    private EncryptionOptions getJmxEncryptionOptions(Map<String, Object> jmxServerOptionsMap)
+    private EncryptionOptions.ClientEncryptionOptions getJmxEncryptionOptions(Map<String, Object> jmxServerOptionsMap)
     {
         if (jmxServerOptionsMap == null)
             return null;
@@ -176,7 +176,7 @@ public class IsolatedJmx
         {
             return null;
         }
-        EncryptionOptions.Builder jmxEncryptionOptionsBuilder = new EncryptionOptions.Builder();
+        EncryptionOptions.ClientEncryptionOptions.Builder jmxEncryptionOptionsBuilder = new EncryptionOptions.ClientEncryptionOptions.Builder();
         String[] cipherSuitesArray = (String[]) encryptionOptionsMap.get(EncryptionOptions.ConfigKey.CIPHER_SUITES.toString());
         if (cipherSuitesArray != null)
         {
@@ -189,9 +189,9 @@ public class IsolatedJmx
         }
 
         Boolean requireClientAuthValue = (Boolean) encryptionOptionsMap.get(EncryptionOptions.ConfigKey.REQUIRE_CLIENT_AUTH.toString());
-        EncryptionOptions.ClientAuth requireClientAuth = requireClientAuthValue == null ?
-                                                         EncryptionOptions.ClientAuth.NOT_REQUIRED :
-                                                         EncryptionOptions.ClientAuth.from(String.valueOf(requireClientAuthValue));
+        EncryptionOptions.ClientEncryptionOptions.ClientAuth requireClientAuth = requireClientAuthValue == null ?
+                                                                                 EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED :
+                                                                                 EncryptionOptions.ClientEncryptionOptions.ClientAuth.from(String.valueOf(requireClientAuthValue));
         Object enabledOption = encryptionOptionsMap.get(EncryptionOptions.ConfigKey.ENABLED.toString());
         boolean enabled = enabledOption != null ? (Boolean) encryptionOptionsMap.get(EncryptionOptions.ConfigKey.ENABLED.toString()) : false;
 

--- a/test/distributed/org/apache/cassandra/distributed/test/AbstractEncryptionOptionsImpl.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/AbstractEncryptionOptionsImpl.java
@@ -56,7 +56,7 @@ import org.apache.cassandra.security.ISslContextFactory;
 import org.apache.cassandra.security.SSLFactory;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.apache.cassandra.distributed.test.AbstractEncryptionOptionsImpl.ConnectResult.CONNECTING;
 import static org.apache.cassandra.distributed.test.AbstractEncryptionOptionsImpl.ConnectResult.UNINITIALIZED;
 import static org.apache.cassandra.utils.concurrent.Condition.newOneTimeCondition;
@@ -118,11 +118,13 @@ public class AbstractEncryptionOptionsImpl extends TestBaseImpl
         final int port;
         final List<String> acceptedProtocols;
         final List<String> cipherSuites;
-        final EncryptionOptions encryptionOptions = new EncryptionOptions.Builder()
-                                                    .withEnabled(true)
-                                                    .withKeyStore(validKeyStorePath).withKeyStorePassword(validKeyStorePassword)
-                                                    .withTrustStore(validTrustStorePath).withTrustStorePassword(validTrustStorePassword)
-                                                    .build();
+        final EncryptionOptions.ClientEncryptionOptions encryptionOptions = new EncryptionOptions.ClientEncryptionOptions.Builder()
+                                                                            .withEnabled(true)
+                                                                            .withKeyStore(validKeyStorePath)
+                                                                            .withKeyStorePassword(validKeyStorePassword)
+                                                                            .withTrustStore(validTrustStorePath)
+                                                                            .withTrustStorePassword(validTrustStorePassword)
+                                                                            .build();
         private Throwable lastThrowable;
         private String lastProtocol;
         private String lastCipher;
@@ -203,7 +205,7 @@ public class AbstractEncryptionOptionsImpl extends TestBaseImpl
             setProtocolAndCipher(null, null);
 
             SslContext sslContext = SSLFactory.getOrCreateSslContext(
-            new EncryptionOptions.Builder(encryptionOptions).withAcceptedProtocols(acceptedProtocols).withCipherSuites(cipherSuites).build(),
+            new EncryptionOptions.ClientEncryptionOptions.Builder(encryptionOptions).withAcceptedProtocols(acceptedProtocols).withCipherSuites(cipherSuites).build(),
             REQUIRED, ISslContextFactory.SocketType.CLIENT, "test");
 
             EventLoopGroup workerGroup = new NioEventLoopGroup();

--- a/test/unit/org/apache/cassandra/auth/MutualTlsAuthenticatorTest.java
+++ b/test/unit/org/apache/cassandra/auth/MutualTlsAuthenticatorTest.java
@@ -38,7 +38,6 @@ import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.EncryptionOptions;
-import org.apache.cassandra.config.EncryptionOptions.Builder;
 import org.apache.cassandra.exceptions.AuthenticationException;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.net.MessagingService;
@@ -49,7 +48,7 @@ import org.apache.cassandra.utils.MBeanWrapper;
 import static org.apache.cassandra.auth.AuthTestUtils.getMockInetAddress;
 import static org.apache.cassandra.auth.AuthTestUtils.initializeIdentityRolesTable;
 import static org.apache.cassandra.auth.AuthTestUtils.loadCertificateChain;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -80,7 +79,7 @@ public class MutualTlsAuthenticatorTest
         StorageService.instance.initServer();
         ((CassandraRoleManager)DatabaseDescriptor.getRoleManager()).loadIdentityStatement();
         final Config config = DatabaseDescriptor.getRawConfig();
-        config.client_encryption_options = new Builder(config.client_encryption_options)
+        config.client_encryption_options = new EncryptionOptions.ClientEncryptionOptions.Builder(config.client_encryption_options)
                                            .withEnabled(true)
                                            .withRequireClientAuth(REQUIRED)
                                            .build();
@@ -186,9 +185,9 @@ public class MutualTlsAuthenticatorTest
                      " & client_encryption_options.require_client_auth to be true";
         MutualTlsAuthenticator mutualTlsAuthenticator = createAndInitializeMtlsAuthenticator();
 
-        config.client_encryption_options = new Builder(config.client_encryption_options)
+        config.client_encryption_options = new EncryptionOptions.ClientEncryptionOptions.Builder(config.client_encryption_options)
                                            .withEnabled(true)
-                                           .withRequireClientAuth(EncryptionOptions.ClientAuth.NOT_REQUIRED)
+                                           .withRequireClientAuth(EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED)
                                            .build();
         expectedException.expect(ConfigurationException.class);
         expectedException.expectMessage(msg);

--- a/test/unit/org/apache/cassandra/auth/MutualTlsWithPasswordFallbackAuthenticatorTest.java
+++ b/test/unit/org/apache/cassandra/auth/MutualTlsWithPasswordFallbackAuthenticatorTest.java
@@ -34,7 +34,6 @@ import org.apache.cassandra.SchemaLoader;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.EncryptionOptions;
-import org.apache.cassandra.config.EncryptionOptions.Builder;
 
 import static org.apache.cassandra.auth.AuthTestUtils.getMockInetAddress;
 import static org.junit.Assert.assertNotNull;
@@ -51,10 +50,10 @@ public class MutualTlsWithPasswordFallbackAuthenticatorTest
         DatabaseDescriptor.daemonInitialization();
         SchemaLoader.loadSchema();
         Config config = DatabaseDescriptor.getRawConfig();
-        config.client_encryption_options =
-        new Builder(config.client_encryption_options).withEnabled(true)
-                                                     .withRequireClientAuth(EncryptionOptions.ClientAuth.OPTIONAL)
-                                                     .build();
+        config.client_encryption_options = new EncryptionOptions.ClientEncryptionOptions.Builder(config.client_encryption_options)
+                                           .withEnabled(true)
+                                           .withRequireClientAuth(EncryptionOptions.ClientEncryptionOptions.ClientAuth.OPTIONAL)
+                                           .build();
         Map<String, String> parameters = Collections.singletonMap("validator_class_name", "org.apache.cassandra.auth.SpiffeCertificateValidator");
         fallbackAuthenticator = new MutualTlsWithPasswordFallbackAuthenticator(parameters);
         fallbackAuthenticator.setup();

--- a/test/unit/org/apache/cassandra/auth/jmx/JMXAuthJMXServerOptionsTest.java
+++ b/test/unit/org/apache/cassandra/auth/jmx/JMXAuthJMXServerOptionsTest.java
@@ -42,7 +42,7 @@ public class JMXAuthJMXServerOptionsTest extends AbstractJMXAuthTest
         String config = Paths.get(ClassLoader.getSystemResource("auth/cassandra-test-jaas.conf").toURI()).toString();
 
         return new JMXServerOptions(true, false, 9999, 0, true,
-                                    new EncryptionOptions(), "TestLogin", config, null, null,
+                                    new EncryptionOptions.ClientEncryptionOptions(), "TestLogin", config, null, null,
                                     NoSuperUserAuthorizationProxy.class.getName());
     }
 }

--- a/test/unit/org/apache/cassandra/config/EncryptionOptionsEqualityTest.java
+++ b/test/unit/org/apache/cassandra/config/EncryptionOptionsEqualityTest.java
@@ -27,8 +27,8 @@ import org.apache.cassandra.security.DefaultSslContextFactory;
 import org.apache.cassandra.security.DummySslContextFactoryImpl;
 import org.apache.cassandra.transport.TlsTestUtils;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -42,13 +42,13 @@ public class EncryptionOptionsEqualityTest
     {
         EncryptionOptions.ServerEncryptionOptions.Builder serverEncryptionOptionsBuilder = new EncryptionOptions.ServerEncryptionOptions.Builder();
         return serverEncryptionOptionsBuilder
+               .withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
+               .withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD)
                .withStoreType("JKS")
                .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
                .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
                .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PATH)
                .withTrustStorePassword(TlsTestUtils.SERVER_TRUSTSTORE_PASSWORD)
-               .withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
-               .withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD)
                .withProtocol("TLSv1.1")
                .withRequireClientAuth(REQUIRED)
                .withRequireEndpointVerification(false)
@@ -57,8 +57,8 @@ public class EncryptionOptionsEqualityTest
 
     @Test
     public void testKeystoreOptions() {
-        EncryptionOptions encryptionOptions1 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ServerEncryptionOptions encryptionOptions1 =
+        new EncryptionOptions.ServerEncryptionOptions.Builder()
         .withStoreType("JKS")
         .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
         .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
@@ -69,8 +69,8 @@ public class EncryptionOptionsEqualityTest
         .withRequireEndpointVerification(false)
         .build();
 
-        EncryptionOptions encryptionOptions2 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ServerEncryptionOptions encryptionOptions2 =
+        new EncryptionOptions.ServerEncryptionOptions.Builder()
         .withStoreType("JKS")
         .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
         .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
@@ -87,8 +87,8 @@ public class EncryptionOptionsEqualityTest
 
     @Test
     public void testKeystoreOptionsWithPasswordFile() {
-        EncryptionOptions encryptionOptions1 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ServerEncryptionOptions encryptionOptions1 =
+        new EncryptionOptions.ServerEncryptionOptions.Builder()
         .withStoreType("JKS")
         .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
         .withKeyStorePasswordFile(TlsTestUtils.SERVER_KEYSTORE_PASSWORD_FILE)
@@ -99,8 +99,8 @@ public class EncryptionOptionsEqualityTest
         .withRequireEndpointVerification(false)
         .build();
 
-        EncryptionOptions encryptionOptions2 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ServerEncryptionOptions encryptionOptions2 =
+        new EncryptionOptions.ServerEncryptionOptions.Builder()
         .withStoreType("JKS")
         .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
         .withKeyStorePasswordFile(TlsTestUtils.SERVER_KEYSTORE_PASSWORD_FILE)
@@ -143,8 +143,8 @@ public class EncryptionOptionsEqualityTest
         Map<String,String> parameters1 = new HashMap<>();
         parameters1.put("key1", "value1");
         parameters1.put("key2", "value2");
-        EncryptionOptions encryptionOptions1 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions1 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DummySslContextFactoryImpl.class.getName(), parameters1))
         .withProtocol("TLSv1.1")
         .withRequireClientAuth(REQUIRED)
@@ -154,8 +154,8 @@ public class EncryptionOptionsEqualityTest
         Map<String,String> parameters2 = new HashMap<>();
         parameters2.put("key1", "value1");
         parameters2.put("key2", "value2");
-        EncryptionOptions encryptionOptions2 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions2 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DummySslContextFactoryImpl.class.getName(), parameters2))
         .withProtocol("TLSv1.1")
         .withRequireClientAuth(REQUIRED)
@@ -172,8 +172,8 @@ public class EncryptionOptionsEqualityTest
         Map<String,String> parameters1 = new HashMap<>();
         parameters1.put("key1", "value1");
         parameters1.put("key2", "value2");
-        EncryptionOptions encryptionOptions1 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions1 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DummySslContextFactoryImpl.class.getName(), parameters1))
         .withProtocol("TLSv1.1")
         .withRequireClientAuth(NOT_REQUIRED)
@@ -183,8 +183,8 @@ public class EncryptionOptionsEqualityTest
         Map<String,String> parameters2 = new HashMap<>();
         parameters2.put("key1", "value1");
         parameters2.put("key2", "value2");
-        EncryptionOptions encryptionOptions2 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions2 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DefaultSslContextFactory.class.getName(), parameters2))
         .withProtocol("TLSv1.1")
         .withRequireClientAuth(NOT_REQUIRED)
@@ -201,8 +201,8 @@ public class EncryptionOptionsEqualityTest
         Map<String,String> parameters1 = new HashMap<>();
         parameters1.put("key1", "value11");
         parameters1.put("key2", "value12");
-        EncryptionOptions encryptionOptions1 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions1 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DummySslContextFactoryImpl.class.getName(), parameters1))
         .withProtocol("TLSv1.1")
         .build();
@@ -210,8 +210,8 @@ public class EncryptionOptionsEqualityTest
         Map<String,String> parameters2 = new HashMap<>();
         parameters2.put("key1", "value21");
         parameters2.put("key2", "value22");
-        EncryptionOptions encryptionOptions2 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions2 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DummySslContextFactoryImpl.class.getName(), parameters2))
         .withProtocol("TLSv1.1")
         .build();

--- a/test/unit/org/apache/cassandra/config/EncryptionOptionsTest.java
+++ b/test/unit/org/apache/cassandra/config/EncryptionOptionsTest.java
@@ -23,11 +23,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.cassandra.io.util.File;
 import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.util.File;
 import org.assertj.core.api.Assertions;
 import org.yaml.snakeyaml.constructor.ConstructorException;
 
@@ -46,11 +46,11 @@ public class EncryptionOptionsTest
 {
     static class EncryptionOptionsTestCase
     {
-        final EncryptionOptions encryptionOptions;
+        final EncryptionOptions.ClientEncryptionOptions encryptionOptions;
         final EncryptionOptions.TlsEncryptionPolicy expected;
         final String description;
 
-        public EncryptionOptionsTestCase(EncryptionOptions encryptionOptions, EncryptionOptions.TlsEncryptionPolicy expected, String description)
+        public EncryptionOptionsTestCase(EncryptionOptions.ClientEncryptionOptions encryptionOptions, EncryptionOptions.TlsEncryptionPolicy expected, String description)
         {
             this.encryptionOptions = encryptionOptions;
             this.expected = expected;
@@ -59,25 +59,25 @@ public class EncryptionOptionsTest
 
         public static EncryptionOptionsTestCase of(Boolean optional, String keystorePath, Boolean enabled, EncryptionOptions.TlsEncryptionPolicy expected)
         {
-            return new EncryptionOptionsTestCase(new EncryptionOptions(new ParameterizedClass("org.apache.cassandra.security.DefaultSslContextFactory",
-                                                                                              new HashMap<>()),
-                                                                       keystorePath, "dummypass", null,
-                                                                       "dummytruststore", "dummypass", null,
-                                                                       Collections.emptyList(), null, null, null, "JKS", "false", false, enabled, optional, null, null)
+            return new EncryptionOptionsTestCase(new EncryptionOptions.ClientEncryptionOptions(new ParameterizedClass("org.apache.cassandra.security.DefaultSslContextFactory",
+                                                                                                                      new HashMap<>()),
+                                                                                               keystorePath, "dummypass", null,
+                                                                                               "dummytruststore", "dummypass", null,
+                                                                                               Collections.emptyList(), null, null, null, "JKS", "false", false, enabled, optional, null, null)
                                                  .applyConfig(),
                                                  expected,
                                                  String.format("optional=%s keystore=%s enabled=%s", optional, keystorePath, enabled));
         }
 
         public static EncryptionOptionsTestCase of(Boolean optional, String keystorePath, Boolean enabled,
-                                                   Map<String,String> customSslContextFactoryParams,
+                                                   Map<String, String> customSslContextFactoryParams,
                                                    EncryptionOptions.TlsEncryptionPolicy expected)
         {
-            return new EncryptionOptionsTestCase(new EncryptionOptions(new ParameterizedClass("org.apache.cassandra.security.DefaultSslContextFactory",
-                                                                                              customSslContextFactoryParams),
-                                                                       keystorePath, "dummypass", null,
-                                                                       "dummytruststore", "dummypass", null,
-                                                                       Collections.emptyList(), null, null, null, "JKS", "false", false, enabled, optional, null, null)
+            return new EncryptionOptionsTestCase(new EncryptionOptions.ClientEncryptionOptions(new ParameterizedClass("org.apache.cassandra.security.DefaultSslContextFactory",
+                                                                                                                      customSslContextFactoryParams),
+                                                                                               keystorePath, "dummypass", null,
+                                                                                               "dummytruststore", "dummypass", null,
+                                                                                               Collections.emptyList(), null, null, null, "JKS", "false", false, enabled, optional, null, null)
                                                  .applyConfig(),
                                                  expected,
                                                  String.format("optional=%s keystore=%s enabled=%s", optional, keystorePath, enabled));
@@ -87,15 +87,15 @@ public class EncryptionOptionsTest
     static final String absentKeystore = "test/conf/missing-keystore-is-not-here";
     static final String presentKeystore = "test/conf/keystore.jks";
     final EncryptionOptionsTestCase[] encryptionOptionTestCases = {
-        //                         Optional    Keystore     Enabled  Expected
-        EncryptionOptionsTestCase.of(null, absentKeystore,  false, UNENCRYPTED),
-        EncryptionOptionsTestCase.of(null, absentKeystore,  true,  ENCRYPTED),
-        EncryptionOptionsTestCase.of(null, presentKeystore, false, OPTIONAL),
-        EncryptionOptionsTestCase.of(null, presentKeystore, true,  ENCRYPTED),
-        EncryptionOptionsTestCase.of(false, absentKeystore, false, UNENCRYPTED),
-        EncryptionOptionsTestCase.of(false, absentKeystore, true,  ENCRYPTED),
-        EncryptionOptionsTestCase.of(true, presentKeystore, false, OPTIONAL),
-        EncryptionOptionsTestCase.of(true, presentKeystore, true,  OPTIONAL)
+    //                         Optional    Keystore     Enabled  Expected
+    EncryptionOptionsTestCase.of(null, absentKeystore, false, UNENCRYPTED),
+    EncryptionOptionsTestCase.of(null, absentKeystore, true, ENCRYPTED),
+    EncryptionOptionsTestCase.of(null, presentKeystore, false, OPTIONAL),
+    EncryptionOptionsTestCase.of(null, presentKeystore, true, ENCRYPTED),
+    EncryptionOptionsTestCase.of(false, absentKeystore, false, UNENCRYPTED),
+    EncryptionOptionsTestCase.of(false, absentKeystore, true, ENCRYPTED),
+    EncryptionOptionsTestCase.of(true, presentKeystore, false, OPTIONAL),
+    EncryptionOptionsTestCase.of(true, presentKeystore, true, OPTIONAL)
     };
 
     @Test
@@ -111,11 +111,11 @@ public class EncryptionOptionsTest
 
     static class ServerEncryptionOptionsTestCase
     {
-        final EncryptionOptions encryptionOptions;
+        final EncryptionOptions.ServerEncryptionOptions encryptionOptions;
         final EncryptionOptions.TlsEncryptionPolicy expected;
         final String description;
 
-        public ServerEncryptionOptionsTestCase(EncryptionOptions encryptionOptions, EncryptionOptions.TlsEncryptionPolicy expected, String description)
+        public ServerEncryptionOptionsTestCase(EncryptionOptions.ServerEncryptionOptions encryptionOptions, EncryptionOptions.TlsEncryptionPolicy expected, String description)
         {
             this.encryptionOptions = encryptionOptions;
             this.expected = expected;
@@ -131,10 +131,10 @@ public class EncryptionOptionsTest
                                                                                                      keystorePath, "dummypass", null,
                                                                                                      keystorePath, "dummypass", null,
                                                                                                      "dummytruststore", "dummypass", null,
-                                                                                               Collections.emptyList(), null, null, null, "JKS", "false", false, optional, internodeEncryption, false, null, null)
+                                                                                                     Collections.emptyList(), null, null, null, "JKS", "false", false, true, optional, internodeEncryption, false, null, null)
                                                        .applyConfig(),
-                                                 expected,
-                                                 String.format("optional=%s keystore=%s internode=%s", optional, keystorePath, internodeEncryption));
+                                                       expected,
+                                                       String.format("optional=%s keystore=%s internode=%s", optional, keystorePath, internodeEncryption));
         }
     }
 
@@ -143,8 +143,8 @@ public class EncryptionOptionsTest
     {
         Map<String, Object> yaml = ImmutableMap.of(
         "server_encryption_options", ImmutableMap.of(
-            "isEnabled", false
-            )
+        "isEnabled", false
+        )
         );
 
         Assertions.assertThatThrownBy(() -> YamlConfigurationLoader.fromMap(yaml, Config.class))
@@ -157,8 +157,8 @@ public class EncryptionOptionsTest
     {
         Map<String, Object> yaml = ImmutableMap.of(
         "server_encryption_options", ImmutableMap.of(
-            "isOptional", false
-            )
+        "isOptional", false
+        )
         );
 
         Assertions.assertThatThrownBy(() -> YamlConfigurationLoader.fromMap(yaml, Config.class))
@@ -171,11 +171,11 @@ public class EncryptionOptionsTest
     {
         Map<String, Object> yaml = ImmutableMap.of(
         "server_encryption_options", ImmutableMap.of(
-            "max_certificate_validity_period", "2d"
-            ),
+        "max_certificate_validity_period", "2d"
+        ),
         "client_encryption_options", ImmutableMap.of(
-            "max_certificate_validity_period", "10d"
-            )
+        "max_certificate_validity_period", "10d"
+        )
         );
 
         Config config = YamlConfigurationLoader.fromMap(yaml, Config.class);
@@ -188,8 +188,8 @@ public class EncryptionOptionsTest
     {
         Map<String, Object> yaml = ImmutableMap.of(
         "server_encryption_options", ImmutableMap.of(
-            "max_certificate_validity_period", "not-a-valid-input"
-            )
+        "max_certificate_validity_period", "not-a-valid-input"
+        )
         );
 
         Assertions.assertThatThrownBy(() -> YamlConfigurationLoader.fromMap(yaml, Config.class))
@@ -202,8 +202,8 @@ public class EncryptionOptionsTest
     {
         Map<String, Object> yaml = ImmutableMap.of(
         "server_encryption_options", ImmutableMap.of(
-            "max_certificate_validity_period", "-2d"
-            )
+        "max_certificate_validity_period", "-2d"
+        )
         );
 
         Assertions.assertThatThrownBy(() -> YamlConfigurationLoader.fromMap(yaml, Config.class))
@@ -213,26 +213,26 @@ public class EncryptionOptionsTest
 
     final ServerEncryptionOptionsTestCase[] serverEncryptionOptionTestCases = {
 
-        //                               Optional    Keystore    Internode  Expected
-        ServerEncryptionOptionsTestCase.of(null, absentKeystore, none, UNENCRYPTED),
-        ServerEncryptionOptionsTestCase.of(null, absentKeystore, rack, OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(null, absentKeystore, dc,   OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(null, absentKeystore, all,  ENCRYPTED),
+    //                               Optional    Keystore    Internode  Expected
+    ServerEncryptionOptionsTestCase.of(null, absentKeystore, none, UNENCRYPTED),
+    ServerEncryptionOptionsTestCase.of(null, absentKeystore, rack, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(null, absentKeystore, dc, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(null, absentKeystore, all, ENCRYPTED),
 
-        ServerEncryptionOptionsTestCase.of(null, presentKeystore, none, OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(null, presentKeystore, rack, OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(null, absentKeystore,  dc,   OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(null, absentKeystore,  all,  ENCRYPTED),
+    ServerEncryptionOptionsTestCase.of(null, presentKeystore, none, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(null, presentKeystore, rack, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(null, absentKeystore, dc, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(null, absentKeystore, all, ENCRYPTED),
 
-        ServerEncryptionOptionsTestCase.of(false, absentKeystore, none, UNENCRYPTED),
-        ServerEncryptionOptionsTestCase.of(false, absentKeystore, rack, OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(false, absentKeystore, dc,   OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(false, absentKeystore, all,  ENCRYPTED),
+    ServerEncryptionOptionsTestCase.of(false, absentKeystore, none, UNENCRYPTED),
+    ServerEncryptionOptionsTestCase.of(false, absentKeystore, rack, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(false, absentKeystore, dc, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(false, absentKeystore, all, ENCRYPTED),
 
-        ServerEncryptionOptionsTestCase.of(true, presentKeystore, none, OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(true, presentKeystore, rack, OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(true, absentKeystore,  dc,   OPTIONAL),
-        ServerEncryptionOptionsTestCase.of(true, absentKeystore,  all,  OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(true, presentKeystore, none, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(true, presentKeystore, rack, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(true, absentKeystore, dc, OPTIONAL),
+    ServerEncryptionOptionsTestCase.of(true, absentKeystore, all, OPTIONAL),
     };
 
     @Test
@@ -246,12 +246,12 @@ public class EncryptionOptionsTest
         }
     }
 
-    @Test(expected =  IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testMisplacedConfigKey()
     {
         Map<String, String> customSslContextFactoryParams = new HashMap<>();
 
-        for(EncryptionOptions.ConfigKey configKey: EncryptionOptions.ConfigKey.values())
+        for (EncryptionOptions.ConfigKey configKey : EncryptionOptions.ConfigKey.values())
         {
             customSslContextFactoryParams.put(configKey.toString(), "my-custom-value");
         }

--- a/test/unit/org/apache/cassandra/cql3/CQLTester.java
+++ b/test/unit/org/apache/cassandra/cql3/CQLTester.java
@@ -620,14 +620,14 @@ public abstract class CQLTester
     public static void requireNativeProtocolClientEncryption()
     {
         DatabaseDescriptor.updateNativeProtocolEncryptionOptions((encryptionOptions) ->
-                                                                 new EncryptionOptions.Builder(encryptionOptions)
+                                                                 new EncryptionOptions.ClientEncryptionOptions.Builder(encryptionOptions)
                                                                  .withEnabled(true)
                                                                  .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
                                                                  .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
                                                                  .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PATH)
                                                                  .withTrustStorePassword(TlsTestUtils.SERVER_TRUSTSTORE_PASSWORD)
                                                                  .withRequireEndpointVerification(false)
-                                                                 .withRequireClientAuth(EncryptionOptions.ClientAuth.OPTIONAL)
+                                                                 .withRequireClientAuth(EncryptionOptions.ClientEncryptionOptions.ClientAuth.OPTIONAL)
                                                                  .build());
     }
 
@@ -1650,7 +1650,7 @@ public abstract class CQLTester
 
     protected SimpleClient newSimpleClient(ProtocolVersion version) throws IOException
     {
-        return new SimpleClient(nativeAddr.getHostAddress(), nativePort, version, version.isBeta(), new EncryptionOptions().applyConfig())
+        return new SimpleClient(nativeAddr.getHostAddress(), nativePort, version, version.isBeta(), new EncryptionOptions.ClientEncryptionOptions().applyConfig())
                .connect(false, false);
     }
 

--- a/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
+++ b/test/unit/org/apache/cassandra/db/virtual/SettingsTableTest.java
@@ -39,7 +39,7 @@ import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.security.SSLFactory;
 import org.yaml.snakeyaml.introspector.Property;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 
 public class SettingsTableTest extends CQLTester
 {

--- a/test/unit/org/apache/cassandra/net/ConnectionTest.java
+++ b/test/unit/org/apache/cassandra/net/ConnectionTest.java
@@ -73,7 +73,7 @@ import org.apache.cassandra.utils.FBUtilities;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
 import static org.apache.cassandra.net.MessagingService.VERSION_40;
 import static org.apache.cassandra.net.NoPayload.noPayload;
 import static org.apache.cassandra.net.MessagingService.current_version;
@@ -177,11 +177,11 @@ public class ConnectionTest
         }
     }
 
-    static final Builder encryptionOptionsBuilder =
+    static final EncryptionOptions.Builder<EncryptionOptions.ServerEncryptionOptions> encryptionOptionsBuilder =
             new Builder()
             .withLegacySslStoragePort(true)
-            .withOptional(true)
             .withInternodeEncryption(EncryptionOptions.ServerEncryptionOptions.InternodeEncryption.all)
+            .withOptional(true)
             .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
             .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
             .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PATH)

--- a/test/unit/org/apache/cassandra/net/HandshakeTest.java
+++ b/test/unit/org/apache/cassandra/net/HandshakeTest.java
@@ -50,8 +50,8 @@ import org.apache.cassandra.security.DefaultSslContextFactory;
 import org.apache.cassandra.transport.TlsTestUtils;
 import org.apache.cassandra.utils.concurrent.AsyncPromise;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.apache.cassandra.net.ConnectionType.SMALL_MESSAGES;
 import static org.apache.cassandra.net.MessagingService.current_version;
 import static org.apache.cassandra.net.MessagingService.minimum_version;
@@ -280,15 +280,17 @@ public class HandshakeTest
 
     private ServerEncryptionOptions getServerEncryptionOptions(SslFallbackConnectionType sslConnectionType, boolean optional)
     {
-        Builder serverEncryptionOptionsBuilder = new Builder().withOptional(optional)
-                                                              .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
-                                                              .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
-                                                              .withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
-                                                              .withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD)
-                                                              .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PATH)
-                                                              .withTrustStorePassword(TlsTestUtils.SERVER_TRUSTSTORE_PASSWORD)
-                                                              .withSslContextFactory((new ParameterizedClass(DefaultSslContextFactory.class.getName(),
-                                                                                                             new HashMap<>())));
+        Builder serverEncryptionOptionsBuilder = new Builder();
+
+        serverEncryptionOptionsBuilder.withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
+                                      .withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD)
+                                      .withOptional(optional)
+                                      .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
+                                      .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
+                                      .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PATH).withTrustStorePassword(TlsTestUtils.SERVER_TRUSTSTORE_PASSWORD)
+                                      .withSslContextFactory((new ParameterizedClass(DefaultSslContextFactory.class.getName(),
+                                                                                      new HashMap<>())));
+
         if (sslConnectionType == SslFallbackConnectionType.MTLS)
         {
             serverEncryptionOptionsBuilder.withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)

--- a/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
+++ b/test/unit/org/apache/cassandra/net/MessagingServiceTest.java
@@ -361,9 +361,9 @@ public class MessagingServiceTest
     @Test
     public void listenRequiredSecureConnection() throws InterruptedException
     {
-        ServerEncryptionOptions serverEncryptionOptions = new Builder().withOptional(false)
-                                                                       .withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
+        ServerEncryptionOptions serverEncryptionOptions = new Builder().withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
                                                                        .withLegacySslStoragePort(false)
+                                                                       .withOptional(false)
                                                                        .build();
         listen(serverEncryptionOptions, false);
     }
@@ -371,9 +371,9 @@ public class MessagingServiceTest
     @Test
     public void listenRequiredSecureConnectionWithBroadcastAddr() throws InterruptedException
     {
-        ServerEncryptionOptions serverEncryptionOptions = new Builder().withOptional(false)
-                                                                       .withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
+        ServerEncryptionOptions serverEncryptionOptions = new Builder().withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
                                                                        .withLegacySslStoragePort(false)
+                                                                       .withOptional(false)
                                                                        .build();
         listen(serverEncryptionOptions, true);
     }
@@ -382,8 +382,8 @@ public class MessagingServiceTest
     public void listenRequiredSecureConnectionWithLegacyPort() throws InterruptedException
     {
         ServerEncryptionOptions serverEncryptionOptions = new Builder().withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
-                                                                       .withOptional(false)
                                                                        .withLegacySslStoragePort(true)
+                                                                       .withOptional(false)
                                                                        .build();
         listen(serverEncryptionOptions, false);
     }
@@ -392,8 +392,8 @@ public class MessagingServiceTest
     public void listenRequiredSecureConnectionWithBroadcastAddrAndLegacyPort() throws InterruptedException
     {
         ServerEncryptionOptions serverEncryptionOptions = new Builder().withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
-                                                                       .withOptional(false)
                                                                        .withLegacySslStoragePort(true)
+                                                                       .withOptional(false)
                                                                        .build();
         listen(serverEncryptionOptions, true);
     }

--- a/test/unit/org/apache/cassandra/security/DefaultSslContextFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/DefaultSslContextFactoryTest.java
@@ -38,13 +38,12 @@ import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.transport.TlsTestUtils;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_TCACTIVE_OPENSSL;
-
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 
 public class DefaultSslContextFactoryTest
 {
-    private Map<String,Object> commonConfig = new HashMap<>();
+    private Map<String, Object> commonConfig = new HashMap<>();
 
     @Before
     public void setup()
@@ -55,7 +54,7 @@ public class DefaultSslContextFactoryTest
         commonConfig.put("cipher_suites", Arrays.asList("TLS_RSA_WITH_AES_128_CBC_SHA"));
     }
 
-    private void addKeystoreOptions(Map<String,Object> config)
+    private void addKeystoreOptions(Map<String, Object> config)
     {
         config.put("keystore", TlsTestUtils.SERVER_KEYSTORE_PATH);
         config.put("keystore_password", TlsTestUtils.SERVER_KEYSTORE_PASSWORD);
@@ -70,15 +69,18 @@ public class DefaultSslContextFactoryTest
     @Test
     public void getSslContextOpenSSL() throws IOException
     {
-        EncryptionOptions.ServerEncryptionOptions options = new Builder().withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PATH)
-                                                                         .withTrustStorePassword(TlsTestUtils.SERVER_TRUSTSTORE_PASSWORD)
-                                                                         .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
-                                                                         .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
-                                                                         .withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
-                                                                         .withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD)
-                                                                         .withRequireClientAuth(NOT_REQUIRED)
-                                                                         .withCipherSuites("TLS_RSA_WITH_AES_128_CBC_SHA")
-                                                                         .build();
+        EncryptionOptions.ServerEncryptionOptions.Builder builder = new Builder();
+        EncryptionOptions.ServerEncryptionOptions options = builder
+                                                            .withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
+                                                            .withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD)
+                                                            .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PATH)
+                                                            .withTrustStorePassword(TlsTestUtils.SERVER_TRUSTSTORE_PASSWORD)
+                                                            .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
+                                                            .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
+                                                            .withRequireClientAuth(NOT_REQUIRED)
+                                                            .withCipherSuites("TLS_RSA_WITH_AES_128_CBC_SHA")
+                                                            .build();
+
         SslContext sslContext = SSLFactory.getOrCreateSslContext(options, REQUIRED, ISslContextFactory.SocketType.CLIENT, "test");
         Assert.assertNotNull(sslContext);
         if (OpenSsl.isAvailable())
@@ -90,7 +92,7 @@ public class DefaultSslContextFactoryTest
     @Test(expected = IOException.class)
     public void buildTrustManagerFactoryWithInvalidTruststoreFile() throws IOException
     {
-        Map<String,Object> config = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
         config.putAll(commonConfig);
         config.put("truststore", "/this/is/probably/not/a/file/on/your/test/machine");
 
@@ -102,7 +104,7 @@ public class DefaultSslContextFactoryTest
     @Test(expected = IOException.class)
     public void buildTrustManagerFactoryWithBadPassword() throws IOException
     {
-        Map<String,Object> config = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
         config.putAll(commonConfig);
         config.put("truststore_password", "HomeOfBadPasswords");
 
@@ -114,7 +116,7 @@ public class DefaultSslContextFactoryTest
     @Test
     public void buildTrustManagerFactoryHappyPath() throws IOException
     {
-        Map<String,Object> config = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
         config.putAll(commonConfig);
 
         DefaultSslContextFactory defaultSslContextFactoryImpl = new DefaultSslContextFactory(config);
@@ -126,7 +128,7 @@ public class DefaultSslContextFactoryTest
     @Test(expected = IOException.class)
     public void buildKeyManagerFactoryWithInvalidKeystoreFile() throws IOException
     {
-        Map<String,Object> config = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
         config.putAll(commonConfig);
         config.put("keystore", "/this/is/probably/not/a/file/on/your/test/machine");
         config.put("keystore_password", "ThisWontMatter");
@@ -139,7 +141,7 @@ public class DefaultSslContextFactoryTest
     @Test(expected = IOException.class)
     public void buildKeyManagerFactoryWithBadPassword() throws IOException
     {
-        Map<String,Object> config = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
         config.putAll(commonConfig);
         addKeystoreOptions(config);
         config.put("keystore_password", "HomeOfBadPasswords");
@@ -151,7 +153,7 @@ public class DefaultSslContextFactoryTest
     @Test
     public void buildKeyManagerFactoryHappyPath() throws IOException
     {
-        Map<String,Object> config = new HashMap<>();
+        Map<String, Object> config = new HashMap<>();
         config.putAll(commonConfig);
 
         DefaultSslContextFactory defaultSslContextFactoryImpl = new DefaultSslContextFactory(config);
@@ -224,12 +226,13 @@ public class DefaultSslContextFactoryTest
     }
 
     @Test
-    public void testDisableOpenSslForInJvmDtests() {
+    public void testDisableOpenSslForInJvmDtests()
+    {
         // The configuration name below is hard-coded intentionally to make sure we don't break the contract without
         // changing the documentation appropriately
         try (WithProperties properties = new WithProperties().set(DISABLE_TCACTIVE_OPENSSL, true))
         {
-            Map<String,Object> config = new HashMap<>();
+            Map<String, Object> config = new HashMap<>();
             config.putAll(commonConfig);
 
             DefaultSslContextFactory defaultSslContextFactoryImpl = new DefaultSslContextFactory(config);

--- a/test/unit/org/apache/cassandra/security/DummySslContextFactoryImpl.java
+++ b/test/unit/org/apache/cassandra/security/DummySslContextFactoryImpl.java
@@ -44,7 +44,7 @@ public class DummySslContextFactoryImpl implements ISslContextFactory
     }
 
     @Override
-    public SSLContext createJSSESslContext(EncryptionOptions.ClientAuth clientAuth) throws SSLException
+    public SSLContext createJSSESslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth) throws SSLException
     {
         return null;
     }
@@ -56,7 +56,7 @@ public class DummySslContextFactoryImpl implements ISslContextFactory
     }
 
     @Override
-    public SslContext createNettySslContext(EncryptionOptions.ClientAuth clientAuth, SocketType socketType,
+    public SslContext createNettySslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth, SocketType socketType,
                                             CipherSuiteFilter cipherFilter) throws SSLException
     {
         return null;

--- a/test/unit/org/apache/cassandra/security/FileBasedSslContextFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/FileBasedSslContextFactoryTest.java
@@ -36,7 +36,7 @@ import org.apache.cassandra.transport.TlsTestUtils;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CASSANDRA_CONFIG;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
 
 public class FileBasedSslContextFactoryTest
 {
@@ -63,6 +63,8 @@ public class FileBasedSslContextFactoryTest
     {
         encryptionOptionsBuilder = new EncryptionOptions.ServerEncryptionOptions.Builder();
         encryptionOptions = encryptionOptionsBuilder
+                            .withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
+                            .withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD)
                             .withSslContextFactory(new ParameterizedClass(TestFileBasedSSLContextFactory.class.getName(),
                                                                           new HashMap<>()))
                             .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PATH)
@@ -71,8 +73,6 @@ public class FileBasedSslContextFactoryTest
                             .withCipherSuites("TLS_RSA_WITH_AES_128_CBC_SHA")
                             .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
                             .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
-                            .withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
-                            .withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD)
                             .build();
     }
 
@@ -99,10 +99,10 @@ public class FileBasedSslContextFactoryTest
     public void testEmptyKeystorePasswords() throws SSLException
     {
         EncryptionOptions.ServerEncryptionOptions localEncryptionOptions = encryptionOptionsBuilder
-                                                                           .withKeyStorePassword("")
-                                                                           .withKeyStore("test/conf/cassandra_ssl_test_nopassword.keystore")
                                                                            .withOutboundKeystorePassword("")
                                                                            .withOutboundKeystore("test/conf/cassandra_ssl_test_nopassword.keystore")
+                                                                           .withKeyStorePassword("")
+                                                                           .withKeyStore("test/conf/cassandra_ssl_test_nopassword.keystore")
                                                                            .build();
 
         Assert.assertEquals("org.apache.cassandra.security.FileBasedSslContextFactoryTest$TestFileBasedSSLContextFactory",
@@ -123,10 +123,10 @@ public class FileBasedSslContextFactoryTest
         // Here we only override password configuration and specify password_file configuration since keystore paths
         // are already loaded in the `encryptionOptions`
         EncryptionOptions.ServerEncryptionOptions localEncryptionOptions = encryptionOptionsBuilder
-                                                                           .withKeyStorePassword(null)
-                                                                           .withKeyStorePasswordFile(TlsTestUtils.SERVER_KEYSTORE_PASSWORD_FILE)
                                                                            .withOutboundKeystorePassword(null)
                                                                            .withOutboundKeystorePasswordFile(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD_FILE)
+                                                                           .withKeyStorePassword(null)
+                                                                           .withKeyStorePasswordFile(TlsTestUtils.SERVER_KEYSTORE_PASSWORD_FILE)
                                                                            .withTrustStorePassword(null)
                                                                            .withTrustStorePasswordFile(TlsTestUtils.SERVER_TRUSTSTORE_PASSWORD_FILE)
                                                                            .build();
@@ -150,10 +150,10 @@ public class FileBasedSslContextFactoryTest
         // Here we only override password configuration and specify password_file configuration since keystore paths
         // are already loaded in the `encryptionOptions`
         encryptionOptionsBuilder
-        .withKeyStorePassword(null)
-        .withKeyStorePasswordFile("/path/to/non-existance-password-file")
         .withOutboundKeystorePassword(null)
         .withOutboundKeystorePasswordFile("/path/to/non-existance-password-file")
+        .withKeyStorePassword(null)
+        .withKeyStorePasswordFile("/path/to/non-existance-password-file")
         .withTrustStorePassword(null)
         .withTrustStorePasswordFile("/path/to/non-existance-password-file")
         .build();

--- a/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/PEMBasedSslContextFactoryTest.java
@@ -39,8 +39,8 @@ import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.transport.TlsTestUtils;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.DISABLE_TCACTIVE_OPENSSL;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.apache.cassandra.security.PEMBasedSslContextFactory.ConfigKey.ENCODED_CERTIFICATES;
 import static org.apache.cassandra.security.PEMBasedSslContextFactory.ConfigKey.ENCODED_KEY;
 import static org.apache.cassandra.security.PEMBasedSslContextFactory.ConfigKey.KEY_PASSWORD;
@@ -215,13 +215,14 @@ public class PEMBasedSslContextFactoryTest
     {
         ParameterizedClass sslContextFactory = new ParameterizedClass(PEMBasedSslContextFactory.class.getSimpleName()
         , new HashMap<>());
-        EncryptionOptions options = new EncryptionOptions.Builder().withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PEM_PATH)
-                                                                   .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH_PEM)
-                                                                   .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
-                                                                   .withRequireClientAuth(NOT_REQUIRED)
-                                                                   .withCipherSuites("TLS_RSA_WITH_AES_128_CBC_SHA")
-                                                                   .withSslContextFactory(sslContextFactory)
-                                                                   .build();
+        EncryptionOptions.ClientEncryptionOptions options = new EncryptionOptions.ClientEncryptionOptions.Builder()
+                                                            .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PEM_PATH)
+                                                            .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH_PEM)
+                                                            .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
+                                                            .withRequireClientAuth(NOT_REQUIRED)
+                                                            .withCipherSuites("TLS_RSA_WITH_AES_128_CBC_SHA")
+                                                            .withSslContextFactory(sslContextFactory)
+                                                            .build();
         SslContext sslContext = SSLFactory.getOrCreateSslContext(options, REQUIRED, ISslContextFactory.SocketType.SERVER, "test");
         Assert.assertNotNull(sslContext);
         if (OpenSsl.isAvailable())
@@ -236,11 +237,11 @@ public class PEMBasedSslContextFactoryTest
         ParameterizedClass sslContextFactory = new ParameterizedClass(PEMBasedSslContextFactory.class.getSimpleName()
         , new HashMap<>());
         EncryptionOptions.ServerEncryptionOptions options =
-        new EncryptionOptions.ServerEncryptionOptions.Builder().withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PEM_PATH)
+        new EncryptionOptions.ServerEncryptionOptions.Builder().withOutboundKeystore(TlsTestUtils.SERVER_KEYSTORE_PATH_PEM)
+                                                               .withOutboundKeystorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
+                                                               .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PEM_PATH)
                                                                .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH_PEM)
                                                                .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
-                                                               .withOutboundKeystore(TlsTestUtils.SERVER_KEYSTORE_PATH_PEM)
-                                                               .withOutboundKeystorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
                                                                .withRequireClientAuth(NOT_REQUIRED)
                                                                .withCipherSuites("TLS_RSA_WITH_AES_128_CBC_SHA")
                                                                .withSslContextFactory(sslContextFactory)

--- a/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
+++ b/test/unit/org/apache/cassandra/security/SSLFactoryTest.java
@@ -1,21 +1,21 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.cassandra.security;
 
 import java.io.FileInputStream;
@@ -51,14 +51,15 @@ import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.io.util.File;
 import org.apache.cassandra.transport.TlsTestUtils;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class SSLFactoryTest
 {
     static final SelfSignedCertificate ssc;
+
     static
     {
         DatabaseDescriptor.daemonInitialization();
@@ -89,22 +90,30 @@ public class SSLFactoryTest
 
     private Builder addKeystoreOptions(ServerEncryptionOptions options)
     {
-        return new Builder(options).withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH)
-                                                           .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
-                                                           .withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
-                                                           .withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD);
+        EncryptionOptions.ServerEncryptionOptions.Builder builder = new EncryptionOptions.ServerEncryptionOptions.Builder(options);
+
+        builder.withOutboundKeystorePassword(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PASSWORD)
+               .withOutboundKeystore(TlsTestUtils.SERVER_OUTBOUND_KEYSTORE_PATH)
+               .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
+               .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH);
+
+        return builder;
     }
 
     private Builder addPEMKeystoreOptions(ServerEncryptionOptions options)
     {
         ParameterizedClass sslContextFactoryClass = new ParameterizedClass("org.apache.cassandra.security.PEMBasedSslContextFactory",
                                                                            new HashMap<>());
-        return new Builder(options).withSslContextFactory(sslContextFactoryClass)
-                                   .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH_PEM)
-                                   .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
-                                   .withOutboundKeystore(TlsTestUtils.SERVER_KEYSTORE_PATH_PEM)
-                                   .withOutboundKeystorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
-                                   .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PEM_PATH);
+        EncryptionOptions.ServerEncryptionOptions.Builder builder = new EncryptionOptions.ServerEncryptionOptions.Builder(options);
+
+        builder.withOutboundKeystore(TlsTestUtils.SERVER_KEYSTORE_PATH_PEM)
+               .withOutboundKeystorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
+               .withSslContextFactory(sslContextFactoryClass)
+               .withKeyStore(TlsTestUtils.SERVER_KEYSTORE_PATH_PEM)
+               .withKeyStorePassword(TlsTestUtils.SERVER_KEYSTORE_PASSWORD)
+               .withTrustStore(TlsTestUtils.SERVER_TRUSTSTORE_PEM_PATH);
+
+        return builder;
     }
 
     @Test
@@ -116,8 +125,8 @@ public class SSLFactoryTest
                                      .withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all);
             ServerEncryptionOptions options = optionsBuilder.build();
             ServerEncryptionOptions legacyOptions = optionsBuilder
-                                                    .withOptional(false)
                                                     .withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
+                                                    .withOptional(false)
                                                     .build();
             options.sslContextFactoryInstance.initHotReloading();
             legacyOptions.sslContextFactoryInstance.initHotReloading();
@@ -192,9 +201,10 @@ public class SSLFactoryTest
             ServerEncryptionOptions options = optionsBuilder.withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.dc)
                                                             .build();
             // emulate InboundSockets and share the cert but with different options, no extra hot reloading init
-            ServerEncryptionOptions legacyOptions = optionsBuilder.withOptional(false)
-                                                                  .withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
-                                                                  .build();
+            ServerEncryptionOptions legacyOptions = optionsBuilder
+                                                    .withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
+                                                    .withOptional(false)
+                                                    .build();
             options.sslContextFactoryInstance.initHotReloading();
             legacyOptions.sslContextFactoryInstance.initHotReloading();
 
@@ -227,8 +237,8 @@ public class SSLFactoryTest
     public void testSslFactorySslInit_BadPassword_ThrowsException() throws IOException
     {
         ServerEncryptionOptions options = addKeystoreOptions(encryptionOptions)
-                                          .withKeyStorePassword("bad password")
                                           .withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
+                                          .withKeyStorePassword("bad password")
                                           .build();
 
         SSLFactory.validateSslContext("testSslFactorySslInit_BadPassword_ThrowsException", options, NOT_REQUIRED, true);
@@ -243,8 +253,8 @@ public class SSLFactoryTest
             ServerEncryptionOptions options = optionsBuilder.build();
             // emulate InboundSockets and share the cert but with different options, no extra hot reloading init
             ServerEncryptionOptions legacyOptions = optionsBuilder
-                                                    .withOptional(false)
                                                     .withInternodeEncryption(ServerEncryptionOptions.InternodeEncryption.all)
+                                                    .withOptional(false)
                                                     .build();
 
             File testKeystoreFile = new File(options.keystore + ".test");
@@ -331,13 +341,14 @@ public class SSLFactoryTest
     }
 
     @Test
-    public void testCacheKeyEqualityForCustomSslContextFactory() {
+    public void testCacheKeyEqualityForCustomSslContextFactory()
+    {
 
-        Map<String,String> parameters1 = new HashMap<>();
+        Map<String, String> parameters1 = new HashMap<>();
         parameters1.put("key1", "value1");
         parameters1.put("key2", "value2");
-        EncryptionOptions encryptionOptions1 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions1 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DummySslContextFactoryImpl.class.getName(), parameters1))
         .withProtocol("TLSv1.1")
         .withRequireClientAuth(REQUIRED)
@@ -347,11 +358,11 @@ public class SSLFactoryTest
         SSLFactory.CacheKey cacheKey1 = new SSLFactory.CacheKey(encryptionOptions1, ISslContextFactory.SocketType.SERVER, "test"
         );
 
-        Map<String,String> parameters2 = new HashMap<>();
+        Map<String, String> parameters2 = new HashMap<>();
         parameters2.put("key1", "value1");
         parameters2.put("key2", "value2");
-        EncryptionOptions encryptionOptions2 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions2 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DummySslContextFactoryImpl.class.getName(), parameters2))
         .withProtocol("TLSv1.1")
         .withRequireClientAuth(REQUIRED)
@@ -365,13 +376,14 @@ public class SSLFactoryTest
     }
 
     @Test
-    public void testCacheKeyInequalityForCustomSslContextFactory() {
+    public void testCacheKeyInequalityForCustomSslContextFactory()
+    {
 
-        Map<String,String> parameters1 = new HashMap<>();
+        Map<String, String> parameters1 = new HashMap<>();
         parameters1.put("key1", "value11");
         parameters1.put("key2", "value12");
-        EncryptionOptions encryptionOptions1 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions1 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DummySslContextFactoryImpl.class.getName(), parameters1))
         .withProtocol("TLSv1.1")
         .build();
@@ -379,11 +391,11 @@ public class SSLFactoryTest
         SSLFactory.CacheKey cacheKey1 = new SSLFactory.CacheKey(encryptionOptions1, ISslContextFactory.SocketType.SERVER, "test"
         );
 
-        Map<String,String> parameters2 = new HashMap<>();
+        Map<String, String> parameters2 = new HashMap<>();
         parameters2.put("key1", "value21");
         parameters2.put("key2", "value22");
-        EncryptionOptions encryptionOptions2 =
-        new EncryptionOptions.Builder()
+        EncryptionOptions.ClientEncryptionOptions encryptionOptions2 =
+        new EncryptionOptions.ClientEncryptionOptions.Builder()
         .withSslContextFactory(new ParameterizedClass(DummySslContextFactoryImpl.class.getName(), parameters2))
         .withProtocol("TLSv1.1")
         .build();
@@ -394,7 +406,8 @@ public class SSLFactoryTest
         Assert.assertNotEquals(cacheKey1, cacheKey2);
     }
 
-    public static class TestFileBasedSSLContextFactory extends FileBasedSslContextFactory {
+    public static class TestFileBasedSSLContextFactory extends FileBasedSslContextFactory
+    {
         public TestFileBasedSSLContextFactory(Map<String, Object> parameters)
         {
             super(parameters);

--- a/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
+++ b/test/unit/org/apache/cassandra/service/ClientWarningsTest.java
@@ -70,7 +70,7 @@ public class ClientWarningsTest extends CQLTester
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
 
         // v4 and higher
-        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, version, true, new EncryptionOptions()))
+        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, version, true, new EncryptionOptions.ClientEncryptionOptions()))
         {
             client.connect(false);
 
@@ -90,7 +90,7 @@ public class ClientWarningsTest extends CQLTester
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, v text)");
 
         // v4 and higher
-        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, version, true, new EncryptionOptions()))
+        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, version, true, new EncryptionOptions.ClientEncryptionOptions()))
         {
             client.connect(false);
 
@@ -112,7 +112,7 @@ public class ClientWarningsTest extends CQLTester
         final int iterations = 10000;
         createTable("CREATE TABLE %s (pk int, ck int, v int, PRIMARY KEY (pk, ck))");
 
-        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, version, true, new EncryptionOptions()))
+        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, version, true, new EncryptionOptions.ClientEncryptionOptions()))
         {
             client.connect(false);
 

--- a/test/unit/org/apache/cassandra/service/NativeTransportServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/NativeTransportServiceTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
 
 public class NativeTransportServiceTest
 {
-    static EncryptionOptions defaultOptions;
+    static EncryptionOptions.ClientEncryptionOptions defaultOptions;
 
     @BeforeClass
     public static void setupDD()
@@ -48,7 +48,7 @@ public class NativeTransportServiceTest
     @After
     public void resetConfig()
     {
-        DatabaseDescriptor.updateNativeProtocolEncryptionOptions(update -> new EncryptionOptions(defaultOptions).applyConfig());
+        DatabaseDescriptor.updateNativeProtocolEncryptionOptions(update -> new EncryptionOptions.ClientEncryptionOptions.Builder(defaultOptions).build().applyConfig());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class NativeTransportServiceTest
     {
         // default ssl settings: client encryption enabled and default native transport port used for ssl only
         DatabaseDescriptor.updateNativeProtocolEncryptionOptions(options ->
-                                                                 new EncryptionOptions.Builder(options)
+                                                                 new EncryptionOptions.ClientEncryptionOptions.Builder(options)
                                                                  .withEnabled(true)
                                                                  .withOptional(false)
                                                                  .build());
@@ -148,7 +148,7 @@ public class NativeTransportServiceTest
     {
         // default ssl settings: client encryption enabled and default native transport port used for optional ssl
         DatabaseDescriptor.updateNativeProtocolEncryptionOptions(options ->
-                                                                 new EncryptionOptions.Builder(options)
+                                                                 new EncryptionOptions.ClientEncryptionOptions.Builder(options)
                                                                  .withEnabled(true)
                                                                  .withOptional(true)
                                                                  .build());

--- a/test/unit/org/apache/cassandra/service/ProtocolBetaVersionTest.java
+++ b/test/unit/org/apache/cassandra/service/ProtocolBetaVersionTest.java
@@ -68,7 +68,7 @@ public class ProtocolBetaVersionTest extends CQLTester
         createTable("CREATE TABLE %s (pk int PRIMARY KEY, v int)");
         assertTrue(betaVersion.isBeta()); // change to another beta version or remove test if no beta version
 
-        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, betaVersion, true, new EncryptionOptions()))
+        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, betaVersion, true, new EncryptionOptions.ClientEncryptionOptions()))
         {
             client.connect(false);
             for (int i = 0; i < 10; i++)
@@ -103,7 +103,7 @@ public class ProtocolBetaVersionTest extends CQLTester
         }
 
         assertTrue(betaVersion.isBeta()); // change to another beta version or remove test if no beta version
-        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, betaVersion, false, new EncryptionOptions()))
+        try (SimpleClient client = new SimpleClient(nativeAddr.getHostAddress(), nativePort, betaVersion, false, new EncryptionOptions.ClientEncryptionOptions()))
         {
             client.connect(false);
             fail("Exception should have been thrown");

--- a/test/unit/org/apache/cassandra/transport/EarlyAuthenticationTest.java
+++ b/test/unit/org/apache/cassandra/transport/EarlyAuthenticationTest.java
@@ -33,7 +33,6 @@ import org.apache.cassandra.auth.IAuthenticator;
 import org.apache.cassandra.auth.MutualTlsAuthenticator;
 import org.apache.cassandra.auth.SpiffeCertificateValidator;
 import org.apache.cassandra.config.EncryptionOptions;
-import org.apache.cassandra.config.EncryptionOptions.Builder;
 import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.cql3.CQLTester;
 import org.apache.cassandra.cql3.QueryProcessor;
@@ -85,22 +84,23 @@ public class EarlyAuthenticationTest extends CQLTester
         });
     }
 
-    private EncryptionOptions clientEncryptionOptions(boolean presentClientCertificate)
+    private EncryptionOptions.ClientEncryptionOptions clientEncryptionOptions(boolean presentClientCertificate)
     {
-        Builder encryptionOptionsBuilder = new Builder().withEnabled(true)
-                                                        .withRequireClientAuth(EncryptionOptions.ClientAuth.OPTIONAL)
-                                                        .withTrustStore(TlsTestUtils.CLIENT_TRUSTSTORE_PATH)
-                                                        .withTrustStorePassword(TlsTestUtils.CLIENT_TRUSTSTORE_PASSWORD)
-                                                        .withSslContextFactory(new ParameterizedClass(SimpleClientSslContextFactory.class.getName()));
+        EncryptionOptions.ClientEncryptionOptions.Builder builder = new EncryptionOptions.ClientEncryptionOptions.Builder();
+        builder.withEnabled(true)
+               .withRequireClientAuth(EncryptionOptions.ClientEncryptionOptions.ClientAuth.OPTIONAL)
+               .withTrustStore(TlsTestUtils.CLIENT_TRUSTSTORE_PATH)
+               .withTrustStorePassword(TlsTestUtils.CLIENT_TRUSTSTORE_PASSWORD)
+               .withSslContextFactory(new ParameterizedClass(SimpleClientSslContextFactory.class.getName()));
 
         if (presentClientCertificate)
         {
-            encryptionOptionsBuilder.withKeyStore(TlsTestUtils.CLIENT_SPIFFE_KEYSTORE_PATH)
+            builder.withKeyStore(TlsTestUtils.CLIENT_SPIFFE_KEYSTORE_PATH)
                                     .withStoreType("JKS")
                                     .withKeyStorePassword(TlsTestUtils.CLIENT_SPIFFE_KEYSTORE_PASSWORD);
         }
 
-        return new EncryptionOptions(encryptionOptionsBuilder.build());
+        return builder.build();
     }
 
     @Test
@@ -180,6 +180,5 @@ public class EarlyAuthenticationTest extends CQLTester
             }
         };
     }
-
 }
 

--- a/test/unit/org/apache/cassandra/transport/MessagePayloadTest.java
+++ b/test/unit/org/apache/cassandra/transport/MessagePayloadTest.java
@@ -127,7 +127,7 @@ public class MessagePayloadTest extends CQLTester
                                                    nativePort,
                                                    ProtocolVersion.V5,
                                                    true,
-                                                   new EncryptionOptions());
+                                                   new EncryptionOptions.ClientEncryptionOptions());
             try
             {
                 client.connect(false);

--- a/test/unit/org/apache/cassandra/transport/SimpleClientSslContextFactory.java
+++ b/test/unit/org/apache/cassandra/transport/SimpleClientSslContextFactory.java
@@ -30,12 +30,12 @@ import io.netty.handler.ssl.SslContextBuilder;
 import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.security.FileBasedSslContextFactory;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.NOT_REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.NOT_REQUIRED;
 
 /**
  * A custom implementation of {@link FileBasedSslContextFactory} to be used by tests utilizing {@link SimpleClient}.
  * <p>
- * Provides a subtly different implementation of {@link #createNettySslContext(EncryptionOptions.ClientAuth, SocketType, CipherSuiteFilter)}
+ * Provides a subtly different implementation of {@link #createNettySslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth, SocketType, CipherSuiteFilter)}
  * that only configures an {@link SslContext} for clients and most importantly only configures a key manager if an
  * outbound keystore is configured, where the existing implementation always does this.  This is useful for tests
  * that try to create a client that uses encryption but does not provide a certificate.
@@ -49,7 +49,7 @@ public class SimpleClientSslContextFactory extends FileBasedSslContextFactory
     }
 
     @Override
-    public SSLContext createJSSESslContext(EncryptionOptions.ClientAuth clientAuth) throws SSLException
+    public SSLContext createJSSESslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth) throws SSLException
     {
         TrustManager[] trustManagers = null;
         if (clientAuth != NOT_REQUIRED)
@@ -76,7 +76,7 @@ public class SimpleClientSslContextFactory extends FileBasedSslContextFactory
     }
 
     @Override
-    public SslContext createNettySslContext(EncryptionOptions.ClientAuth clientAuth, SocketType socketType,
+    public SslContext createNettySslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth clientAuth, SocketType socketType,
                                             CipherSuiteFilter cipherFilter) throws SSLException
     {
         SslContextBuilder builder = SslContextBuilder.forClient();

--- a/test/unit/org/apache/cassandra/transport/TlsTestUtils.java
+++ b/test/unit/org/apache/cassandra/transport/TlsTestUtils.java
@@ -86,17 +86,18 @@ public class TlsTestUtils
     public static String CLIENT_TRUSTSTORE_PATH = "test/conf/cassandra_ssl_test.truststore";
     public static String CLIENT_TRUSTSTORE_PASSWORD = "cassandra";
 
-    public static EncryptionOptions getClientEncryptionOptions()
+    public static EncryptionOptions.ClientEncryptionOptions getClientEncryptionOptions()
     {
-        return new EncryptionOptions(new EncryptionOptions.Builder()
+        return new EncryptionOptions.ClientEncryptionOptions.Builder()
                               .withEnabled(true)
-                              .withRequireClientAuth(EncryptionOptions.ClientAuth.OPTIONAL)
+                              .withRequireClientAuth(EncryptionOptions.ClientEncryptionOptions.ClientAuth.OPTIONAL)
                               .withOptional(true)
                               .withKeyStore(SERVER_KEYSTORE_PATH)
                               .withKeyStorePassword(SERVER_KEYSTORE_PASSWORD)
                               .withTrustStore(SERVER_TRUSTSTORE_PATH)
                               .withTrustStorePassword(SERVER_TRUSTSTORE_PASSWORD)
-                              .withRequireEndpointVerification(false).build());
+                              .withRequireEndpointVerification(false)
+                              .build();
     }
 
     public static void configureWithMutualTlsWithPasswordFallbackAuthenticator(Config config)
@@ -129,7 +130,7 @@ public class TlsTestUtils
     {
         return RemoteEndpointAwareJdkSSLOptions.builder()
                                                .withSSLContext(getClientSslContextFactory(provideClientCert)
-                                                               .createJSSESslContext(EncryptionOptions.ClientAuth.OPTIONAL))
+                                                               .createJSSESslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth.OPTIONAL))
                                                .build();
     }
 
@@ -139,7 +140,7 @@ public class TlsTestUtils
         {
             return RemoteEndpointAwareJdkSSLOptions.builder()
                                                    .withSSLContext(getClientSslContextFactory(keystorePath, truststorePath)
-                                                                   .createJSSESslContext(EncryptionOptions.ClientAuth.OPTIONAL))
+                                                                   .createJSSESslContext(EncryptionOptions.ClientEncryptionOptions.ClientAuth.OPTIONAL))
                                                    .build();
         }
         catch (SSLException e)

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.cassandra.config.EncryptionOptions;
-import org.apache.cassandra.config.EncryptionOptions.Builder;
 import org.apache.cassandra.stress.util.ResultLogger;
 
 import static java.lang.String.format;
@@ -45,12 +44,12 @@ public class SettingsTransport implements Serializable
         this.credentials = credentials;
     }
 
-    public EncryptionOptions getEncryptionOptions()
+    public EncryptionOptions.ClientEncryptionOptions getEncryptionOptions()
     {
-        EncryptionOptions encOptions = new EncryptionOptions().applyConfig();
+        EncryptionOptions.ClientEncryptionOptions encOptions = new EncryptionOptions.ClientEncryptionOptions().applyConfig();
         if (options.trustStore.present())
         {
-            Builder encOptionsBuilder = new Builder(encOptions)
+            EncryptionOptions.Builder<EncryptionOptions.ClientEncryptionOptions> encOptionsBuilder = new EncryptionOptions.ClientEncryptionOptions.Builder(encOptions)
                                         .withEnabled(true)
                                         .withTrustStore(options.trustStore.value())
                                         .withTrustStorePassword(options.trustStorePw.setByUser() ? options.trustStorePw.value() : credentials.transportTruststorePassword)

--- a/tools/stress/src/org/apache/cassandra/stress/settings/StressSettings.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/StressSettings.java
@@ -139,7 +139,7 @@ public class StressSettings implements Serializable
                 if (client != null)
                     return client;
 
-                EncryptionOptions encOptions = transport.getEncryptionOptions();
+                EncryptionOptions.ClientEncryptionOptions encOptions = transport.getEncryptionOptions();
                 JavaDriverClient c = new JavaDriverClient(this, node.nodes, port.nativePort, encOptions);
                 c.connect(mode.compression());
                 if (keyspace != null)

--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -41,7 +41,7 @@ import org.apache.cassandra.config.EncryptionOptions;
 import org.apache.cassandra.security.SSLFactory;
 import org.apache.cassandra.stress.settings.StressSettings;
 
-import static org.apache.cassandra.config.EncryptionOptions.ClientAuth.REQUIRED;
+import static org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions.ClientAuth.REQUIRED;
 
 public class JavaDriverClient
 {
@@ -60,7 +60,7 @@ public class JavaDriverClient
     public final int connectionsPerHost;
 
     private final ProtocolVersion protocolVersion;
-    private final EncryptionOptions encryptionOptions;
+    private final EncryptionOptions.ClientEncryptionOptions encryptionOptions;
     private Cluster cluster;
     private Session session;
     private final LoadBalancingPolicy loadBalancingPolicy;
@@ -69,15 +69,15 @@ public class JavaDriverClient
 
     public JavaDriverClient(StressSettings settings, String host, int port)
     {
-        this(settings, Collections.singletonList(host), port, new EncryptionOptions());
+        this(settings, Collections.singletonList(host), port, new EncryptionOptions.ClientEncryptionOptions());
     }
 
     public JavaDriverClient(StressSettings settings, List<String> hosts, int port)
     {
-        this(settings, hosts, port, new EncryptionOptions());
+        this(settings, hosts, port, new EncryptionOptions.ClientEncryptionOptions());
     }
 
-    public JavaDriverClient(StressSettings settings, List<String> hosts, int port, EncryptionOptions encryptionOptions)
+    public JavaDriverClient(StressSettings settings, List<String> hosts, int port, EncryptionOptions.ClientEncryptionOptions encryptionOptions)
     {
         this.protocolVersion = settings.mode.protocolVersion;
         this.hosts = hosts;
@@ -85,7 +85,7 @@ public class JavaDriverClient
         this.username = settings.mode.username;
         this.password = settings.mode.password;
         this.authProvider = settings.mode.authProvider;
-        this.encryptionOptions = new EncryptionOptions(encryptionOptions).applyConfig();
+        this.encryptionOptions = encryptionOptions.applyConfig();
         this.loadBalancingPolicy = loadBalancingPolicy(settings);
         this.connectionsPerHost = settings.mode.connectionsPerHost == null ? 8 : settings.mode.connectionsPerHost;
 


### PR DESCRIPTION
Encryption options should be `ClientEncryptionOptions` and `ServerEncryptionOptions` with `EncryptionOptions` being abstract.

Builders should be also split into server and client flavor.

Right now, there is `EncryptionOptions` and we have `ServerEncryptionOptions` which extend them. That does not make a lot of sense. If we want to share code for server options, we should have client options specifically as well, extending the very same abstract encryption options class as client options do.

This makes the code to be way more readable, if it is clearly split between client and server options everywhere.